### PR TITLE
[TS] LPS-135245 Add new undocumented portal.properties property that allows to our final customers to force the asyncronous indexation as a workaround

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequest.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/IndexerRequest.java
@@ -21,6 +21,8 @@ import com.liferay.portal.kernel.messaging.proxy.ProxyModeThreadLocal;
 import com.liferay.portal.kernel.model.ClassedModel;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.util.ClassUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 
 import java.lang.reflect.Method;
 
@@ -40,7 +42,7 @@ public class IndexerRequest {
 
 		_indexer = new NoAutoCommitIndexer<>(indexer);
 
-		_forceSync = ProxyModeThreadLocal.isForceSync();
+		_forceSync = _getForceSync();
 		_modelClassName = classedModel.getModelClassName();
 		_modelPrimaryKey = (Long)_classedModel.getPrimaryKeyObj();
 	}
@@ -55,7 +57,7 @@ public class IndexerRequest {
 		_modelPrimaryKey = modelPrimaryKey;
 
 		_classedModel = null;
-		_forceSync = ProxyModeThreadLocal.isForceSync();
+		_forceSync = _getForceSync();
 	}
 
 	@Override
@@ -132,6 +134,14 @@ public class IndexerRequest {
 		sb.append("}");
 
 		return sb.toString();
+	}
+
+	private boolean _getForceSync() {
+		if (GetterUtil.getBoolean(PropsUtil.get("index.async.indexing"))) {
+			return false;
+		}
+
+		return ProxyModeThreadLocal.isForceSync();
 	}
 
 	private final ClassedModel _classedModel;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-135245

The previous PR was rejected, see: https://github.com/brianchandotcom/liferay-portal/pull/105406#issuecomment-897199454

The final agreement between @arboliveira and @brianchandotcom is to use a new portal.properties that will be hidden
 - It won't be documented
 - It won't have a default value in the portal.properties
 - It won't be added to the PropsValues.java / PropsKeys.java

We will only give it to the customers that have problems with the sync indexation as a workaround until they find the root cause in their Elasticsearch server.

/cc @BryanEngler

