### PR TITLE
LPS-137974_3

### DIFF
--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/CountryLocalServiceTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/CountryLocalServiceTest.java
@@ -20,12 +20,13 @@ import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.OrganizationConstants;
+import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.CountryLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
-import com.liferay.portal.kernel.service.RegionService;
+import com.liferay.portal.kernel.service.RegionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
@@ -122,6 +123,14 @@ public class CountryLocalServiceTest {
 					null, null, country.getCountryId(), null, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS)));
 
+		// Region
+
+		Region region = _addRegion(country.getCountryId());
+
+		_regionLocalService.updateRegionLocalization(
+			region, RandomTestUtil.randomString(2),
+			RandomTestUtil.randomString());
+
 		_countryLocalService.deleteCountry(country);
 
 		Assert.assertNull(
@@ -146,6 +155,18 @@ public class CountryLocalServiceTest {
 					OrganizationConstants.ANY_PARENT_ORGANIZATION_ID, null,
 					null, null, country.getCountryId(), null, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS)));
+
+		// Assert region is deleted
+
+		Assert.assertNull(
+			_regionLocalService.fetchRegion(region.getRegionId()));
+
+		// Assert region localization is deleted
+
+		Assert.assertTrue(
+			ListUtil.isEmpty(
+				_regionLocalService.getRegionLocalizations(
+					region.getRegionId())));
 	}
 
 	@Test
@@ -273,6 +294,14 @@ public class CountryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext());
 	}
 
+	private Region _addRegion(long countryId) throws Exception {
+		return _regionLocalService.addRegion(
+			countryId, RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomDouble(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
 	private void _assertSearchCountriesPaginationSort(
 			List<Country> expectedCountries, String keywords,
 			OrderByComparator<Country> orderByComparator,
@@ -308,6 +337,6 @@ public class CountryLocalServiceTest {
 	private static OrganizationLocalService _organizationLocalService;
 
 	@Inject
-	private static RegionService _regionService;
+	private static RegionLocalService _regionLocalService;
 
 }

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/RegionLocalServiceTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/RegionLocalServiceTest.java
@@ -59,8 +59,17 @@ public class RegionLocalServiceTest {
 
 		Region region = _addRegion(country.getCountryId());
 
+		String languageId = RandomTestUtil.randomString(2);
+
+		_regionLocalService.updateRegionLocalization(
+			region, languageId, RandomTestUtil.randomString());
+
 		Assert.assertNotNull(
 			_regionLocalService.fetchRegion(region.getRegionId()));
+
+		Assert.assertNotNull(
+			_regionLocalService.getRegionLocalization(
+				region.getRegionId(), languageId));
 	}
 
 	@Test
@@ -68,6 +77,10 @@ public class RegionLocalServiceTest {
 		Country country = _addCountry();
 
 		Region region = _addRegion(country.getCountryId());
+
+		_regionLocalService.updateRegionLocalization(
+			region, RandomTestUtil.randomString(2),
+			RandomTestUtil.randomString());
 
 		// Address
 
@@ -106,6 +119,13 @@ public class RegionLocalServiceTest {
 
 		Assert.assertNull(
 			_regionLocalService.fetchRegion(region.getRegionId()));
+
+		// Assert region localization is deleted
+
+		Assert.assertTrue(
+			ListUtil.isEmpty(
+				_regionLocalService.getRegionLocalizations(
+					region.getRegionId())));
 
 		// Assert address is deleted
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
@@ -803,11 +803,6 @@ public class CPDefinitionLocalServiceImpl
 			cProductLocalService.deleteCProduct(cpDefinition.getCProductId());
 		}
 
-		// Commerce product definition localization
-
-		cpDefinitionLocalizationPersistence.removeByCPDefinitionId(
-			cpDefinition.getCPDefinitionId());
-
 		// Commerce product definition specification option values
 
 		cpDefinitionSpecificationOptionValueLocalService.

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/persistence/impl/CPDefinitionPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/persistence/impl/CPDefinitionPersistenceImpl.java
@@ -19,8 +19,10 @@ import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPDefinitionTable;
 import com.liferay.commerce.product.model.impl.CPDefinitionImpl;
 import com.liferay.commerce.product.model.impl.CPDefinitionModelImpl;
+import com.liferay.commerce.product.service.persistence.CPDefinitionLocalizationPersistence;
 import com.liferay.commerce.product.service.persistence.CPDefinitionPersistence;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -5551,6 +5553,9 @@ public class CPDefinitionPersistenceImpl
 
 	@Override
 	protected CPDefinition removeImpl(CPDefinition cpDefinition) {
+		cpDefinitionLocalizationPersistence.removeByCPDefinitionId(
+			cpDefinition.getCPDefinitionId());
+
 		Session session = null;
 
 		try {
@@ -6128,6 +6133,10 @@ public class CPDefinitionPersistenceImpl
 
 	@ServiceReference(type = FinderCache.class)
 	protected FinderCache finderCache;
+
+	@BeanReference(type = CPDefinitionLocalizationPersistence.class)
+	protected CPDefinitionLocalizationPersistence
+		cpDefinitionLocalizationPersistence;
 
 	private static Long _getTime(Date date) {
 		if (date == null) {

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -163,9 +163,6 @@ public class FriendlyURLEntryLocalServiceImpl
 	public FriendlyURLEntry deleteFriendlyURLEntry(
 		FriendlyURLEntry friendlyURLEntry) {
 
-		friendlyURLEntryLocalizationPersistence.removeByFriendlyURLEntryId(
-			friendlyURLEntry.getFriendlyURLEntryId());
-
 		FriendlyURLEntry deletedFriendlyURLEntry =
 			friendlyURLEntryPersistence.remove(friendlyURLEntry);
 
@@ -232,9 +229,6 @@ public class FriendlyURLEntryLocalServiceImpl
 				groupId, classNameId, classPK);
 
 		for (FriendlyURLEntry friendlyURLEntry : friendlyURLEntries) {
-			friendlyURLEntryLocalizationPersistence.removeByFriendlyURLEntryId(
-				friendlyURLEntry.getFriendlyURLEntryId());
-
 			friendlyURLEntryPersistence.remove(friendlyURLEntry);
 		}
 

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/persistence/impl/FriendlyURLEntryPersistenceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/persistence/impl/FriendlyURLEntryPersistenceImpl.java
@@ -2298,6 +2298,9 @@ public class FriendlyURLEntryPersistenceImpl
 
 	@Override
 	protected FriendlyURLEntry removeImpl(FriendlyURLEntry friendlyURLEntry) {
+		friendlyURLEntryLocalizationPersistence.removeByFriendlyURLEntryId(
+			friendlyURLEntry.getFriendlyURLEntryId());
+
 		Session session = null;
 
 		try {
@@ -3018,6 +3021,10 @@ public class FriendlyURLEntryPersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
+
+	@Reference
+	protected FriendlyURLEntryLocalizationPersistence
+		friendlyURLEntryLocalizationPersistence;
 
 	private static final String _SQL_SELECT_FRIENDLYURLENTRY =
 		"SELECT friendlyURLEntry FROM FriendlyURLEntry friendlyURLEntry";

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1227,11 +1227,6 @@ public class JournalArticleLocalServiceImpl
 			updatePreviousApprovedArticle(article);
 		}
 
-		// Article localization
-
-		journalArticleLocalizationPersistence.removeByArticlePK(
-			article.getId());
-
 		// Asset
 
 		if (article.isDraft() || article.isInTrash()) {

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LVEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LVEntryPersistenceImpl.java
@@ -44,6 +44,7 @@ import com.liferay.portal.tools.service.builder.test.model.LVEntryTable;
 import com.liferay.portal.tools.service.builder.test.model.impl.LVEntryImpl;
 import com.liferay.portal.tools.service.builder.test.model.impl.LVEntryModelImpl;
 import com.liferay.portal.tools.service.builder.test.service.persistence.BigDecimalEntryPersistence;
+import com.liferay.portal.tools.service.builder.test.service.persistence.LVEntryLocalizationPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.LVEntryPersistence;
 
 import java.io.Serializable;
@@ -6153,6 +6154,9 @@ public class LVEntryPersistenceImpl
 		lvEntryToBigDecimalEntryTableMapper.deleteLeftPrimaryKeyTableMappings(
 			lvEntry.getPrimaryKey());
 
+		lvEntryLocalizationPersistence.removeByLvEntryId(
+			lvEntry.getLvEntryId());
+
 		Session session = null;
 
 		try {
@@ -7087,6 +7091,9 @@ public class LVEntryPersistenceImpl
 		<LVEntry,
 		 com.liferay.portal.tools.service.builder.test.model.BigDecimalEntry>
 			lvEntryToBigDecimalEntryTableMapper;
+
+	@BeanReference(type = LVEntryLocalizationPersistence.class)
+	protected LVEntryLocalizationPersistence lvEntryLocalizationPersistence;
 
 	private static final String _SQL_SELECT_LVENTRY =
 		"SELECT lvEntry FROM LVEntry lvEntry";

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LocalizedEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LocalizedEntryPersistenceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.tools.service.builder.test.service.persistence.impl;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -31,6 +32,7 @@ import com.liferay.portal.tools.service.builder.test.model.LocalizedEntry;
 import com.liferay.portal.tools.service.builder.test.model.LocalizedEntryTable;
 import com.liferay.portal.tools.service.builder.test.model.impl.LocalizedEntryImpl;
 import com.liferay.portal.tools.service.builder.test.model.impl.LocalizedEntryModelImpl;
+import com.liferay.portal.tools.service.builder.test.service.persistence.LocalizedEntryLocalizationPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.LocalizedEntryPersistence;
 
 import java.io.Serializable;
@@ -224,6 +226,9 @@ public class LocalizedEntryPersistenceImpl
 
 	@Override
 	protected LocalizedEntry removeImpl(LocalizedEntry localizedEntry) {
+		localizedEntryLocalizationPersistence.removeByLocalizedEntryId(
+			localizedEntry.getLocalizedEntryId());
+
 		Session session = null;
 
 		try {
@@ -564,6 +569,10 @@ public class LocalizedEntryPersistenceImpl
 
 	@ServiceReference(type = FinderCache.class)
 	protected FinderCache finderCache;
+
+	@BeanReference(type = LocalizedEntryLocalizationPersistence.class)
+	protected LocalizedEntryLocalizationPersistence
+		localizedEntryLocalizationPersistence;
 
 	private static final String _SQL_SELECT_LOCALIZEDENTRY =
 		"SELECT localizedEntry FROM LocalizedEntry localizedEntry";

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -179,6 +179,20 @@ import org.osgi.service.component.annotations.Reference;
 	</#if>
 </#list>
 
+<#if entity.localizedEntity??>
+	<#assign
+		referenceEntity = serviceBuilder.getEntity(entity.localizedEntity.name)
+	/>
+
+	<#if referenceEntity.hasPersistence()>
+		<#if dependencyInjectorDS>
+			import ${referenceEntity.apiPackagePath}.model.${referenceEntity.name};
+		<#else>
+			import ${referenceEntity.apiPackagePath}.service.persistence.${referenceEntity.name}Persistence;
+		</#if>
+	</#if>
+</#if>
+
 /**
  * The persistence implementation for the ${entity.humanName} service.
  *
@@ -688,6 +702,15 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 				${entity.variableName}To${referenceEntity.name}TableMapper.deleteLeftPrimaryKeyTableMappings(${entity.variableName}.getPrimaryKey());
 			</#if>
 		</#list>
+
+		<#if entity.localizedEntity??>
+			<#assign
+				localizedEntity = entity.localizedEntity
+				pkEntityColumn = entity.PKEntityColumns?first
+			/>
+
+			${localizedEntity.variableName}Persistence.removeBy${pkEntityColumn.methodName}(${entity.variableName}.get${pkEntityColumn.methodName}());
+		</#if>
 
 		Session session = null;
 
@@ -2863,6 +2886,24 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 			protected TableMapper<${entity.name}, ${referenceEntity.apiPackagePath}.model.${referenceEntity.name}> ${entity.variableName}To${referenceEntity.name}TableMapper;
 		</#if>
 	</#list>
+
+	<#if entity.localizedEntity??>
+		<#assign
+			referenceEntity = serviceBuilder.getEntity(entity.localizedEntity.name)
+		/>
+
+		<#if !dependencyInjectorDS || (referenceEntity.apiPackagePath == apiPackagePath)>
+			<#if dependencyInjectorDS>
+				@Reference
+			<#elseif osgiModule && (referenceEntity.apiPackagePath != apiPackagePath)>
+				@ServiceReference(type = ${referenceEntity.name}Persistence.class)
+			<#else>
+				@BeanReference(type = ${referenceEntity.name}Persistence.class)
+			</#if>
+
+			protected ${referenceEntity.name}Persistence ${referenceEntity.variableName}Persistence;
+		</#if>
+	</#if>
 
 	<#if entity.isHierarchicalTree()>
 		protected NestedSetsTreeManager<${entity.name}> nestedSetsTreeManager = new PersistenceNestedSetsTreeManager<${entity.name}>(this, "${entity.table}", "${entity.name}", ${entity.name}Impl.class, "${pkEntityColumn.DBName}", "${scopeEntityColumn.DBName}", "left${pkEntityColumn.methodName}", "right${pkEntityColumn.methodName}");

--- a/portal-impl/src/com/liferay/portal/service/base/RegionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/RegionLocalServiceBaseImpl.java
@@ -145,11 +145,10 @@ public abstract class RegionLocalServiceBaseImpl
 	 *
 	 * @param region the region
 	 * @return the region that was removed
-	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	@Override
-	public Region deleteRegion(Region region) throws PortalException {
+	public Region deleteRegion(Region region) {
 		return regionPersistence.remove(region);
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CountryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CountryLocalServiceImpl.java
@@ -115,11 +115,6 @@ public class CountryLocalServiceImpl extends CountryLocalServiceBaseImpl {
 
 		addressLocalService.deleteCountryAddresses(country.getCountryId());
 
-		// Country localizations
-
-		countryLocalizationPersistence.removeByCountryId(
-			country.getCountryId());
-
 		// Organizations
 
 		_updateOrganizations(country.getCountryId());

--- a/portal-impl/src/com/liferay/portal/service/impl/CountryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CountryLocalServiceImpl.java
@@ -126,7 +126,7 @@ public class CountryLocalServiceImpl extends CountryLocalServiceBaseImpl {
 
 		// Regions
 
-		regionPersistence.removeByCountryId(country.getCountryId());
+		regionLocalService.deleteCountryRegions(country.getCountryId());
 
 		return country;
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -101,7 +101,24 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 
 		// Organizations
 
-		_updateOrganizations(region.getRegionId());
+		ActionableDynamicQuery actionableDynamicQuery =
+			organizationLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property regionIdProperty = PropertyFactoryUtil.forName(
+					"regionId");
+
+				dynamicQuery.add(regionIdProperty.eq(region.getRegionId()));
+			});
+		actionableDynamicQuery.setPerformActionMethod(
+			(Organization organization) -> {
+				organization.setRegionId(0);
+
+				organizationLocalService.updateOrganization(organization);
+			});
+
+		actionableDynamicQuery.performActions();
 
 		return region;
 	}
@@ -201,27 +218,6 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 		if (Validator.isNull(name)) {
 			throw new RegionNameException();
 		}
-	}
-
-	private void _updateOrganizations(long regionId) throws PortalException {
-		ActionableDynamicQuery actionableDynamicQuery =
-			organizationLocalService.getActionableDynamicQuery();
-
-		actionableDynamicQuery.setAddCriteriaMethod(
-			dynamicQuery -> {
-				Property regionIdProperty = PropertyFactoryUtil.forName(
-					"regionId");
-
-				dynamicQuery.add(regionIdProperty.eq(regionId));
-			});
-		actionableDynamicQuery.setPerformActionMethod(
-			(Organization organization) -> {
-				organization.setRegionId(0);
-
-				organizationLocalService.updateOrganization(organization);
-			});
-
-		actionableDynamicQuery.performActions();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.service.base.RegionLocalServiceBaseImpl;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -90,7 +89,7 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 
 		// Region Localizations
 
-		updateRegionLocalizations(region, Collections.emptyMap());
+		regionLocalizationPersistence.removeByRegionId(region.getRegionId());
 
 		// Region
 

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -14,15 +14,14 @@
 
 package com.liferay.portal.service.impl;
 
-import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
-import com.liferay.portal.kernel.dao.orm.Property;
-import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RegionCodeException;
 import com.liferay.portal.kernel.exception.RegionNameException;
 import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.OrganizationTable;
 import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -101,24 +100,21 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 
 		// Organizations
 
-		ActionableDynamicQuery actionableDynamicQuery =
-			organizationLocalService.getActionableDynamicQuery();
+		for (Organization organization :
+				organizationPersistence.<List<Organization>>dslQuery(
+					DSLQueryFactoryUtil.select(
+						OrganizationTable.INSTANCE
+					).from(
+						OrganizationTable.INSTANCE
+					).where(
+						OrganizationTable.INSTANCE.regionId.eq(
+							region.getRegionId())
+					))) {
 
-		actionableDynamicQuery.setAddCriteriaMethod(
-			dynamicQuery -> {
-				Property regionIdProperty = PropertyFactoryUtil.forName(
-					"regionId");
+			organization.setRegionId(0);
 
-				dynamicQuery.add(regionIdProperty.eq(region.getRegionId()));
-			});
-		actionableDynamicQuery.setPerformActionMethod(
-			(Organization organization) -> {
-				organization.setRegionId(0);
-
-				organizationLocalService.updateOrganization(organization);
-			});
-
-		actionableDynamicQuery.performActions();
+			organizationLocalService.updateOrganization(organization);
+		}
 
 		return region;
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -86,10 +86,6 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 	@Override
 	public Region deleteRegion(Region region) {
 
-		// Region Localizations
-
-		regionLocalizationPersistence.removeByRegionId(region.getRegionId());
-
 		// Region
 
 		regionPersistence.remove(region);

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -17,6 +17,7 @@ package com.liferay.portal.service.impl;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RegionCodeException;
 import com.liferay.portal.kernel.exception.RegionNameException;
@@ -29,6 +30,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.service.base.RegionLocalServiceBaseImpl;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -68,7 +70,12 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 
 	@Override
 	public void deleteCountryRegions(long countryId) {
-		regionPersistence.removeByCountryId(countryId);
+		for (Region region :
+				getRegions(
+					countryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			deleteRegion(region);
+		}
 	}
 
 	@Override
@@ -80,6 +87,10 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 
 	@Override
 	public Region deleteRegion(Region region) throws PortalException {
+
+		// Region Localizations
+
+		updateRegionLocalizations(region, Collections.emptyMap());
 
 		// Region
 

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -69,7 +69,7 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 	}
 
 	@Override
-	public void deleteCountryRegions(long countryId) {
+	public void deleteCountryRegions(long countryId) throws PortalException {
 		for (Region region :
 				getRegions(
 					countryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -67,7 +67,7 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 	}
 
 	@Override
-	public void deleteCountryRegions(long countryId) throws PortalException {
+	public void deleteCountryRegions(long countryId) {
 		for (Region region :
 				getRegions(
 					countryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
@@ -84,7 +84,7 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 	}
 
 	@Override
-	public Region deleteRegion(Region region) throws PortalException {
+	public Region deleteRegion(Region region) {
 
 		// Region Localizations
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/CountryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/CountryPersistenceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.service.persistence.impl;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
@@ -32,6 +33,7 @@ import com.liferay.portal.kernel.model.CountryTable;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.persistence.CountryLocalizationPersistence;
 import com.liferay.portal.kernel.service.persistence.CountryPersistence;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -5077,6 +5079,9 @@ public class CountryPersistenceImpl
 
 	@Override
 	protected Country removeImpl(Country country) {
+		countryLocalizationPersistence.removeByCountryId(
+			country.getCountryId());
+
 		Session session = null;
 
 		try {
@@ -5645,6 +5650,9 @@ public class CountryPersistenceImpl
 	public void destroy() {
 		EntityCacheUtil.removeCache(CountryImpl.class.getName());
 	}
+
+	@BeanReference(type = CountryLocalizationPersistence.class)
+	protected CountryLocalizationPersistence countryLocalizationPersistence;
 
 	private static final String _SQL_SELECT_COUNTRY =
 		"SELECT country FROM Country country";

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RegionPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RegionPersistenceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.service.persistence.impl;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
@@ -32,6 +33,7 @@ import com.liferay.portal.kernel.model.RegionTable;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.persistence.RegionLocalizationPersistence;
 import com.liferay.portal.kernel.service.persistence.RegionPersistence;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -3116,6 +3118,8 @@ public class RegionPersistenceImpl
 
 	@Override
 	protected Region removeImpl(Region region) {
+		regionLocalizationPersistence.removeByRegionId(region.getRegionId());
+
 		Session session = null;
 
 		try {
@@ -3602,6 +3606,9 @@ public class RegionPersistenceImpl
 	public void destroy() {
 		EntityCacheUtil.removeCache(RegionImpl.class.getName());
 	}
+
+	@BeanReference(type = RegionLocalizationPersistence.class)
+	protected RegionLocalizationPersistence regionLocalizationPersistence;
 
 	private static final String _SQL_SELECT_REGION =
 		"SELECT region FROM Region region";

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalService.java
@@ -96,7 +96,7 @@ public interface RegionLocalService
 	@Transactional(enabled = false)
 	public Region createRegion(long regionId);
 
-	public void deleteCountryRegions(long countryId);
+	public void deleteCountryRegions(long countryId) throws PortalException;
 
 	/**
 	 * @throws PortalException

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalService.java
@@ -96,7 +96,7 @@ public interface RegionLocalService
 	@Transactional(enabled = false)
 	public Region createRegion(long regionId);
 
-	public void deleteCountryRegions(long countryId) throws PortalException;
+	public void deleteCountryRegions(long countryId);
 
 	/**
 	 * @throws PortalException
@@ -128,10 +128,9 @@ public interface RegionLocalService
 	 *
 	 * @param region the region
 	 * @return the region that was removed
-	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
-	public Region deleteRegion(Region region) throws PortalException;
+	public Region deleteRegion(Region region);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceUtil.java
@@ -88,7 +88,9 @@ public class RegionLocalServiceUtil {
 		return getService().createRegion(regionId);
 	}
 
-	public static void deleteCountryRegions(long countryId) {
+	public static void deleteCountryRegions(long countryId)
+		throws PortalException {
+
 		getService().deleteCountryRegions(countryId);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceUtil.java
@@ -88,9 +88,7 @@ public class RegionLocalServiceUtil {
 		return getService().createRegion(regionId);
 	}
 
-	public static void deleteCountryRegions(long countryId)
-		throws PortalException {
-
+	public static void deleteCountryRegions(long countryId) {
 		getService().deleteCountryRegions(countryId);
 	}
 
@@ -128,9 +126,8 @@ public class RegionLocalServiceUtil {
 	 *
 	 * @param region the region
 	 * @return the region that was removed
-	 * @throws PortalException
 	 */
-	public static Region deleteRegion(Region region) throws PortalException {
+	public static Region deleteRegion(Region region) {
 		return getService().deleteRegion(region);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceWrapper.java
@@ -79,7 +79,9 @@ public class RegionLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteCountryRegions(long countryId) {
+	public void deleteCountryRegions(long countryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_regionLocalService.deleteCountryRegions(countryId);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceWrapper.java
@@ -79,9 +79,7 @@ public class RegionLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteCountryRegions(long countryId)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
+	public void deleteCountryRegions(long countryId) {
 		_regionLocalService.deleteCountryRegions(countryId);
 	}
 
@@ -123,12 +121,10 @@ public class RegionLocalServiceWrapper
 	 *
 	 * @param region the region
 	 * @return the region that was removed
-	 * @throws PortalException
 	 */
 	@Override
 	public com.liferay.portal.kernel.model.Region deleteRegion(
-			com.liferay.portal.kernel.model.Region region)
-		throws com.liferay.portal.kernel.exception.PortalException {
+		com.liferay.portal.kernel.model.Region region) {
 
 		return _regionLocalService.deleteRegion(region);
 	}


### PR DESCRIPTION
- LPS-137974 Delete RegionLocalization records linked to the Region ones
- LPS-137974 Throw PortalException in deleteCountryRegions method
- LPS-137974 Regen ant build-service-portal
- LPS-137974 Update tests: Add a RegionLocalization entry and check it is deleted when deleting a Country or a Region
- LPS-137974 Simplify.
- LPS-137974 Inline method with only one usage.
- LPS-137974 Use DSL.
- LPS-137974 Remove unnessesary throws.
- LPS-137974 Build Service.
- LPS-137974 Delete the localization records at service builder level in the removeImpl method of persistenceImpl classes
- LPS-137974 Remove unnecessary code in *LocalServiceImpl classes, the localized records deletion will be done by service builder
- LPS-137974 Regen services
