### PR TITLE
references_checker_CompanyLocalServiceTest_2

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/AccountGroupModelListener.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/AccountGroupModelListener.java
@@ -20,6 +20,7 @@ import com.liferay.account.service.AccountGroupLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -32,6 +33,10 @@ public class AccountGroupModelListener extends BaseModelListener<AccountGroup> {
 
 	@Override
 	public void onAfterRemove(AccountGroup accountGroup) {
+		if (CompanyThreadLocal.isDeleteInProcess()) {
+			return;
+		}
+
 		if (accountGroup.isDefaultAccountGroup()) {
 			throw new ModelListenerException(
 				new DefaultAccountGroupException.

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/security/permission/contributor/AccountRoleContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/security/permission/contributor/AccountRoleContributor.java
@@ -53,14 +53,10 @@ public class AccountRoleContributor implements RoleContributor {
 			Group group = _groupLocalService.getGroup(
 				roleCollection.getGroupId());
 
-			User user = roleCollection.getUser();
-
-			if (user.getCompanyId() != group.getCompanyId()) {
-				return;
-			}
-
 			if (!Objects.equals(
 					AccountEntry.class.getName(), group.getClassName())) {
+
+				User user = roleCollection.getUser();
 
 				AccountEntry currentAccountEntry =
 					_currentAccountEntryManager.getCurrentAccountEntry(
@@ -80,6 +76,8 @@ public class AccountRoleContributor implements RoleContributor {
 				}
 			}
 			else {
+				User user = roleCollection.getUser();
+
 				if (_accountEntryUserRelLocalService.hasAccountEntryUserRel(
 						group.getClassPK(), user.getUserId())) {
 

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/security/permission/contributor/AccountRoleContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/security/permission/contributor/AccountRoleContributor.java
@@ -53,10 +53,14 @@ public class AccountRoleContributor implements RoleContributor {
 			Group group = _groupLocalService.getGroup(
 				roleCollection.getGroupId());
 
+			User user = roleCollection.getUser();
+
+			if (user.getCompanyId() != group.getCompanyId()) {
+				return;
+			}
+
 			if (!Objects.equals(
 					AccountEntry.class.getName(), group.getClassName())) {
-
-				User user = roleCollection.getUser();
 
 				AccountEntry currentAccountEntry =
 					_currentAccountEntryManager.getCurrentAccountEntry(
@@ -76,8 +80,6 @@ public class AccountRoleContributor implements RoleContributor {
 				}
 			}
 			else {
-				User user = roleCollection.getUser();
-
 				if (_accountEntryUserRelLocalService.hasAccountEntryUserRel(
 						group.getClassPK(), user.getUserId())) {
 

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/CountryLocalServiceTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/CountryLocalServiceTest.java
@@ -20,12 +20,13 @@ import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.OrganizationConstants;
+import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.CountryLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
-import com.liferay.portal.kernel.service.RegionService;
+import com.liferay.portal.kernel.service.RegionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
@@ -122,6 +123,14 @@ public class CountryLocalServiceTest {
 					null, null, country.getCountryId(), null, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS)));
 
+		// Region
+
+		Region region = _addRegion(country.getCountryId());
+
+		_regionLocalService.updateRegionLocalization(
+			region, RandomTestUtil.randomString(2),
+			RandomTestUtil.randomString());
+
 		_countryLocalService.deleteCountry(country);
 
 		Assert.assertNull(
@@ -146,6 +155,18 @@ public class CountryLocalServiceTest {
 					OrganizationConstants.ANY_PARENT_ORGANIZATION_ID, null,
 					null, null, country.getCountryId(), null, QueryUtil.ALL_POS,
 					QueryUtil.ALL_POS)));
+
+		// Assert region is deleted
+
+		Assert.assertNull(
+			_regionLocalService.fetchRegion(region.getRegionId()));
+
+		// Assert region localization is deleted
+
+		Assert.assertTrue(
+			ListUtil.isEmpty(
+				_regionLocalService.getRegionLocalizations(
+					region.getRegionId())));
 	}
 
 	@Test
@@ -273,6 +294,14 @@ public class CountryLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext());
 	}
 
+	private Region _addRegion(long countryId) throws Exception {
+		return _regionLocalService.addRegion(
+			countryId, RandomTestUtil.randomBoolean(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomDouble(),
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
 	private void _assertSearchCountriesPaginationSort(
 			List<Country> expectedCountries, String keywords,
 			OrderByComparator<Country> orderByComparator,
@@ -308,6 +337,6 @@ public class CountryLocalServiceTest {
 	private static OrganizationLocalService _organizationLocalService;
 
 	@Inject
-	private static RegionService _regionService;
+	private static RegionLocalService _regionLocalService;
 
 }

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/RegionLocalServiceTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/service/test/RegionLocalServiceTest.java
@@ -59,8 +59,17 @@ public class RegionLocalServiceTest {
 
 		Region region = _addRegion(country.getCountryId());
 
+		String languageId = RandomTestUtil.randomString(2);
+
+		_regionLocalService.updateRegionLocalization(
+			region, languageId, RandomTestUtil.randomString());
+
 		Assert.assertNotNull(
 			_regionLocalService.fetchRegion(region.getRegionId()));
+
+		Assert.assertNotNull(
+			_regionLocalService.getRegionLocalization(
+				region.getRegionId(), languageId));
 	}
 
 	@Test
@@ -68,6 +77,10 @@ public class RegionLocalServiceTest {
 		Country country = _addCountry();
 
 		Region region = _addRegion(country.getCountryId());
+
+		_regionLocalService.updateRegionLocalization(
+			region, RandomTestUtil.randomString(2),
+			RandomTestUtil.randomString());
 
 		// Address
 
@@ -106,6 +119,13 @@ public class RegionLocalServiceTest {
 
 		Assert.assertNull(
 			_regionLocalService.fetchRegion(region.getRegionId()));
+
+		// Assert region localization is deleted
+
+		Assert.assertTrue(
+			ListUtil.isEmpty(
+				_regionLocalService.getRegionLocalizations(
+					region.getRegionId())));
 
 		// Assert address is deleted
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionLocalServiceImpl.java
@@ -803,11 +803,6 @@ public class CPDefinitionLocalServiceImpl
 			cProductLocalService.deleteCProduct(cpDefinition.getCProductId());
 		}
 
-		// Commerce product definition localization
-
-		cpDefinitionLocalizationPersistence.removeByCPDefinitionId(
-			cpDefinition.getCPDefinitionId());
-
 		// Commerce product definition specification option values
 
 		cpDefinitionSpecificationOptionValueLocalService.

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/persistence/impl/CPDefinitionPersistenceImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/persistence/impl/CPDefinitionPersistenceImpl.java
@@ -19,8 +19,10 @@ import com.liferay.commerce.product.model.CPDefinition;
 import com.liferay.commerce.product.model.CPDefinitionTable;
 import com.liferay.commerce.product.model.impl.CPDefinitionImpl;
 import com.liferay.commerce.product.model.impl.CPDefinitionModelImpl;
+import com.liferay.commerce.product.service.persistence.CPDefinitionLocalizationPersistence;
 import com.liferay.commerce.product.service.persistence.CPDefinitionPersistence;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -5551,6 +5553,9 @@ public class CPDefinitionPersistenceImpl
 
 	@Override
 	protected CPDefinition removeImpl(CPDefinition cpDefinition) {
+		cpDefinitionLocalizationPersistence.removeByCPDefinitionId(
+			cpDefinition.getCPDefinitionId());
+
 		Session session = null;
 
 		try {
@@ -6128,6 +6133,10 @@ public class CPDefinitionPersistenceImpl
 
 	@ServiceReference(type = FinderCache.class)
 	protected FinderCache finderCache;
+
+	@BeanReference(type = CPDefinitionLocalizationPersistence.class)
+	protected CPDefinitionLocalizationPersistence
+		cpDefinitionLocalizationPersistence;
 
 	private static Long _getTime(Date date) {
 		if (date == null) {

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -194,11 +194,11 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
-		checkCompanyDeletion(company);
-
 		for (String webId : PortalInstances.getWebIds()) {
 			Assert.assertNotEquals(companyWebId, webId);
 		}
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -243,6 +243,8 @@ public class CompanyLocalServiceTest {
 			"The company organization child group should delete with the " +
 				"company",
 			group);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -263,8 +265,6 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
-		checkCompanyDeletion(company);
-
 		companyGroup = GroupLocalServiceUtil.fetchGroup(
 			companyGroup.getGroupId());
 
@@ -274,6 +274,8 @@ public class CompanyLocalServiceTest {
 			companyStagingGroup.getGroupId());
 
 		Assert.assertNull(companyStagingGroup);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -303,6 +305,8 @@ public class CompanyLocalServiceTest {
 			"test.xml", "", "", "test".getBytes(), null, null, serviceContext);
 
 		CompanyLocalServiceUtil.deleteCompany(companyId);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -349,6 +353,8 @@ public class CompanyLocalServiceTest {
 				layoutSetPrototype.getLayoutSetPrototypeId());
 
 		Assert.assertNull(layoutSetPrototype);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -387,6 +393,8 @@ public class CompanyLocalServiceTest {
 			});
 
 		CompanyLocalServiceUtil.deleteCompany(companyId);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -409,8 +417,6 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
-		checkCompanyDeletion(company);
-
 		parentGroup = GroupLocalServiceUtil.fetchGroup(
 			parentGroup.getGroupId());
 
@@ -419,6 +425,8 @@ public class CompanyLocalServiceTest {
 		group = GroupLocalServiceUtil.fetchGroup(group.getGroupId());
 
 		Assert.assertNull(group);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -451,6 +459,8 @@ public class CompanyLocalServiceTest {
 			companyOrganizationGroup.getGroupId());
 
 		Assert.assertNull(companyOrganizationGroup);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -475,8 +485,6 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
-		checkCompanyDeletion(company);
-
 		userGroup = UserGroupLocalServiceUtil.fetchUserGroup(
 			userGroup.getUserGroupId());
 
@@ -485,6 +493,8 @@ public class CompanyLocalServiceTest {
 		user = UserLocalServiceUtil.fetchUser(user.getUserId());
 
 		Assert.assertNull(user);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -522,8 +532,6 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
-		checkCompanyDeletion(company);
-
 		Assert.assertNull(RoleLocalServiceUtil.fetchRole(role.getRoleId()));
 
 		Assert.assertNull(
@@ -535,6 +543,8 @@ public class CompanyLocalServiceTest {
 				user.getUserId(), group.getGroupId(), role.getRoleId()));
 
 		Assert.assertNull(UserLocalServiceUtil.fetchUser(user.getUserId()));
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test(expected = NoSuchPasswordPolicyException.class)
@@ -547,6 +557,8 @@ public class CompanyLocalServiceTest {
 
 		PasswordPolicyLocalServiceUtil.getDefaultPasswordPolicy(
 			company.getCompanyId());
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -564,6 +576,8 @@ public class CompanyLocalServiceTest {
 			company.getCompanyId(), GroupConstants.ANY_PARENT_GROUP_ID, false);
 
 		Assert.assertEquals(0, count);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -581,6 +595,8 @@ public class CompanyLocalServiceTest {
 			company.getCompanyId(), false);
 
 		Assert.assertEquals(0, count);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -595,6 +611,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertEquals(
 			layoutSetPrototypes.toString(), 0, layoutSetPrototypes.size());
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test(expected = NoSuchPasswordPolicyException.class)
@@ -618,6 +636,8 @@ public class CompanyLocalServiceTest {
 				}
 
 			});
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -631,6 +651,8 @@ public class CompanyLocalServiceTest {
 			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID);
 
 		Assert.assertEquals(0, count);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -643,6 +665,8 @@ public class CompanyLocalServiceTest {
 			companyId -> Assert.assertNotEquals(
 				"Company instance was not deleted", company.getCompanyId(),
 				(long)companyId));
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -669,6 +693,8 @@ public class CompanyLocalServiceTest {
 				}
 
 			});
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -692,6 +718,8 @@ public class CompanyLocalServiceTest {
 				}
 
 			});
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -704,6 +732,8 @@ public class CompanyLocalServiceTest {
 			company.getCompanyId());
 
 		Assert.assertEquals(roles.toString(), 0, roles.size());
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -743,10 +773,10 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
-		checkCompanyDeletion(company);
-
 		Assert.assertEquals(UserGroupRole.class.getName(), list.get(0));
 		Assert.assertEquals(Role.class.getName(), list.get(1));
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -759,6 +789,8 @@ public class CompanyLocalServiceTest {
 			company.getCompanyId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		Assert.assertEquals(users.toString(), 0, users.size());
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test(expected = NoSuchVirtualHostException.class)
@@ -768,6 +800,8 @@ public class CompanyLocalServiceTest {
 		CompanyLocalServiceUtil.deleteCompany(company);
 
 		VirtualHostLocalServiceUtil.getVirtualHost(company.getWebId());
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -777,6 +811,8 @@ public class CompanyLocalServiceTest {
 		Company company = addCompany();
 
 		CompanyLocalServiceUtil.deleteCompany(company);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test(expected = RequiredCompanyException.class)
@@ -900,8 +936,6 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
-		checkCompanyDeletion(company);
-
 		Assert.assertEquals(languageId, user.getLanguageId());
 		Assert.assertEquals("CET", user.getTimeZoneId());
 	}
@@ -923,8 +957,6 @@ public class CompanyLocalServiceTest {
 		GroupLocalServiceUtil.deleteGroup(group);
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
-
-		checkCompanyDeletion(company);
 	}
 
 	@Test
@@ -955,8 +987,6 @@ public class CompanyLocalServiceTest {
 			company, new String[] {RandomTestUtil.randomString()}, false);
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
-
-		checkCompanyDeletion(company);
 	}
 
 	@Test
@@ -1006,9 +1036,12 @@ public class CompanyLocalServiceTest {
 			serviceContext);
 	}
 
-	protected void checkCompanyDeletion(Company company) throws Exception {
+	protected void assertTablesWithInvalidRecords(
+			String columnName, long wrongValue)
+		throws Exception {
+
 		List<String> invalidTables = getTablesWithInvalidRecords(
-			"companyId", company.getCompanyId());
+			columnName, wrongValue);
 
 		Assert.assertEquals(Collections.emptyList(), invalidTables);
 	}
@@ -1154,7 +1187,7 @@ public class CompanyLocalServiceTest {
 		finally {
 			CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
-			checkCompanyDeletion(company);
+			assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 
 			field.set(null, value);
 		}
@@ -1186,8 +1219,6 @@ public class CompanyLocalServiceTest {
 		}
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
-
-		checkCompanyDeletion(company);
 	}
 
 	private List<String> _registerModelListeners() {

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -21,11 +21,8 @@ import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
-import com.liferay.portal.kernel.dao.db.DBInspector;
-import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.CompanyMxException;
 import com.liferay.portal.kernel.exception.CompanyNameException;
@@ -68,6 +65,7 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.VirtualHostLocalServiceUtil;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.DBAssertionUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
@@ -97,13 +95,6 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -198,7 +189,8 @@ public class CompanyLocalServiceTest {
 			Assert.assertNotEquals(companyWebId, webId);
 		}
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -244,7 +236,8 @@ public class CompanyLocalServiceTest {
 				"company",
 			group);
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -275,7 +268,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertNull(companyStagingGroup);
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -306,7 +300,8 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(companyId);
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -354,7 +349,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertNull(layoutSetPrototype);
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -394,7 +390,8 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(companyId);
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -426,7 +423,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertNull(group);
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -460,7 +458,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertNull(companyOrganizationGroup);
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -494,7 +493,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertNull(user);
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -544,7 +544,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertNull(UserLocalServiceUtil.fetchUser(user.getUserId()));
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test(expected = NoSuchPasswordPolicyException.class)
@@ -558,7 +559,8 @@ public class CompanyLocalServiceTest {
 		PasswordPolicyLocalServiceUtil.getDefaultPasswordPolicy(
 			company.getCompanyId());
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -577,7 +579,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertEquals(0, count);
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -596,7 +599,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertEquals(0, count);
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -612,7 +616,8 @@ public class CompanyLocalServiceTest {
 		Assert.assertEquals(
 			layoutSetPrototypes.toString(), 0, layoutSetPrototypes.size());
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test(expected = NoSuchPasswordPolicyException.class)
@@ -637,7 +642,8 @@ public class CompanyLocalServiceTest {
 
 			});
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -652,7 +658,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertEquals(0, count);
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -666,7 +673,8 @@ public class CompanyLocalServiceTest {
 				"Company instance was not deleted", company.getCompanyId(),
 				(long)companyId));
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -694,7 +702,8 @@ public class CompanyLocalServiceTest {
 
 			});
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -719,7 +728,8 @@ public class CompanyLocalServiceTest {
 
 			});
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -733,7 +743,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertEquals(roles.toString(), 0, roles.size());
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -776,7 +787,8 @@ public class CompanyLocalServiceTest {
 		Assert.assertEquals(UserGroupRole.class.getName(), list.get(0));
 		Assert.assertEquals(Role.class.getName(), list.get(1));
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -790,7 +802,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertEquals(users.toString(), 0, users.size());
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test(expected = NoSuchVirtualHostException.class)
@@ -801,7 +814,8 @@ public class CompanyLocalServiceTest {
 
 		VirtualHostLocalServiceUtil.getVirtualHost(company.getWebId());
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -812,7 +826,8 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company);
 
-		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
 	}
 
 	@Test(expected = RequiredCompanyException.class)
@@ -1036,16 +1051,6 @@ public class CompanyLocalServiceTest {
 			serviceContext);
 	}
 
-	protected void assertTablesWithInvalidRecords(
-			String columnName, long wrongValue)
-		throws Exception {
-
-		List<String> invalidTables = getTablesWithInvalidRecords(
-			columnName, wrongValue);
-
-		Assert.assertEquals(Collections.emptyList(), invalidTables);
-	}
-
 	protected ServiceContext getServiceContext(long companyId) {
 		ServiceContext serviceContext = new ServiceContext();
 
@@ -1054,64 +1059,6 @@ public class CompanyLocalServiceTest {
 		serviceContext.setCompanyId(companyId);
 
 		return serviceContext;
-	}
-
-	protected List<String> getTablesWithInvalidRecords(
-			String columnName, long wrongValue)
-		throws Exception {
-
-		List<String> invalidTables = new ArrayList<>();
-
-		try (Connection connection = DataAccess.getConnection()) {
-			DBInspector dbInspector = new DBInspector(connection);
-
-			String catalog = dbInspector.getCatalog();
-			String schema = dbInspector.getSchema();
-
-			DatabaseMetaData databaseMetaData = connection.getMetaData();
-
-			try (ResultSet tableResultSet = databaseMetaData.getTables(
-					catalog, schema, null, new String[] {"TABLE"})) {
-
-				while (tableResultSet.next()) {
-					String tableName = dbInspector.normalizeName(
-						tableResultSet.getString("TABLE_NAME"));
-
-					if (!dbInspector.hasColumn(tableName, columnName)) {
-						continue;
-					}
-
-					if (hasInvalidRecords(
-							connection, tableName, columnName, wrongValue)) {
-
-						invalidTables.add(tableName);
-					}
-				}
-			}
-		}
-
-		return invalidTables;
-	}
-
-	protected boolean hasInvalidRecords(
-			Connection connection, String tableName, String columnName,
-			long wrongValue)
-		throws SQLException {
-
-		String query = StringBundler.concat(
-			"select count(*) from ", tableName, " where ", columnName, " = ",
-			wrongValue);
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				query);
-			ResultSet resultSet = preparedStatement.executeQuery()) {
-
-			if (resultSet.next() && (resultSet.getInt(1) > 0)) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	protected void testUpdateCompanyNames(
@@ -1187,7 +1134,8 @@ public class CompanyLocalServiceTest {
 		finally {
 			CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
-			assertTablesWithInvalidRecords("companyId", company.getCompanyId());
+			DBAssertionUtil.assertTablesWithInvalidRecords(
+				"companyId", company.getCompanyId());
 
 			field.set(null, value);
 		}

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -21,8 +21,11 @@ import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.CompanyMxException;
 import com.liferay.portal.kernel.exception.CompanyNameException;
@@ -94,6 +97,13 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -184,6 +194,8 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
+		checkCompanyDeletion(company);
+
 		for (String webId : PortalInstances.getWebIds()) {
 			Assert.assertNotEquals(companyWebId, webId);
 		}
@@ -250,6 +262,8 @@ public class CompanyLocalServiceTest {
 		Group companyStagingGroup = companyGroup.getStagingGroup();
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
+
+		checkCompanyDeletion(company);
 
 		companyGroup = GroupLocalServiceUtil.fetchGroup(
 			companyGroup.getGroupId());
@@ -395,6 +409,8 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
+		checkCompanyDeletion(company);
+
 		parentGroup = GroupLocalServiceUtil.fetchGroup(
 			parentGroup.getGroupId());
 
@@ -459,6 +475,8 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
+		checkCompanyDeletion(company);
+
 		userGroup = UserGroupLocalServiceUtil.fetchUserGroup(
 			userGroup.getUserGroupId());
 
@@ -503,6 +521,8 @@ public class CompanyLocalServiceTest {
 			user.getUserId(), group.getGroupId(), role.getRoleId());
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
+
+		checkCompanyDeletion(company);
 
 		Assert.assertNull(RoleLocalServiceUtil.fetchRole(role.getRoleId()));
 
@@ -723,6 +743,8 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
+		checkCompanyDeletion(company);
+
 		Assert.assertEquals(UserGroupRole.class.getName(), list.get(0));
 		Assert.assertEquals(Role.class.getName(), list.get(1));
 	}
@@ -878,6 +900,8 @@ public class CompanyLocalServiceTest {
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
+		checkCompanyDeletion(company);
+
 		Assert.assertEquals(languageId, user.getLanguageId());
 		Assert.assertEquals("CET", user.getTimeZoneId());
 	}
@@ -899,6 +923,8 @@ public class CompanyLocalServiceTest {
 		GroupLocalServiceUtil.deleteGroup(group);
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
+
+		checkCompanyDeletion(company);
 	}
 
 	@Test
@@ -929,6 +955,8 @@ public class CompanyLocalServiceTest {
 			company, new String[] {RandomTestUtil.randomString()}, false);
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
+
+		checkCompanyDeletion(company);
 	}
 
 	@Test
@@ -978,6 +1006,13 @@ public class CompanyLocalServiceTest {
 			serviceContext);
 	}
 
+	protected void checkCompanyDeletion(Company company) throws Exception {
+		List<String> invalidTables = getTablesWithInvalidRecords(
+			"companyId", company.getCompanyId());
+
+		Assert.assertEquals(Collections.emptyList(), invalidTables);
+	}
+
 	protected ServiceContext getServiceContext(long companyId) {
 		ServiceContext serviceContext = new ServiceContext();
 
@@ -986,6 +1021,64 @@ public class CompanyLocalServiceTest {
 		serviceContext.setCompanyId(companyId);
 
 		return serviceContext;
+	}
+
+	protected List<String> getTablesWithInvalidRecords(
+			String columnName, long wrongValue)
+		throws Exception {
+
+		List<String> invalidTables = new ArrayList<>();
+
+		try (Connection connection = DataAccess.getConnection()) {
+			DBInspector dbInspector = new DBInspector(connection);
+
+			String catalog = dbInspector.getCatalog();
+			String schema = dbInspector.getSchema();
+
+			DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+			try (ResultSet tableResultSet = databaseMetaData.getTables(
+					catalog, schema, null, new String[] {"TABLE"})) {
+
+				while (tableResultSet.next()) {
+					String tableName = dbInspector.normalizeName(
+						tableResultSet.getString("TABLE_NAME"));
+
+					if (!dbInspector.hasColumn(tableName, columnName)) {
+						continue;
+					}
+
+					if (hasInvalidRecords(
+							connection, tableName, columnName, wrongValue)) {
+
+						invalidTables.add(tableName);
+					}
+				}
+			}
+		}
+
+		return invalidTables;
+	}
+
+	protected boolean hasInvalidRecords(
+			Connection connection, String tableName, String columnName,
+			long wrongValue)
+		throws SQLException {
+
+		String query = StringBundler.concat(
+			"select count(*) from ", tableName, " where ", columnName, " = ",
+			wrongValue);
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				query);
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next() && (resultSet.getInt(1) > 0)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	protected void testUpdateCompanyNames(
@@ -1061,6 +1154,8 @@ public class CompanyLocalServiceTest {
 		finally {
 			CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 
+			checkCompanyDeletion(company);
+
 			field.set(null, value);
 		}
 	}
@@ -1091,6 +1186,8 @@ public class CompanyLocalServiceTest {
 		}
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
+
+		checkCompanyDeletion(company);
 	}
 
 	private List<String> _registerModelListeners() {

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/model/listener/CompanyModelListener.java
@@ -12,12 +12,10 @@
  * details.
  */
 
-package com.liferay.account.internal.model.listener;
+package com.liferay.dispatch.internal.model.listener;
 
-import com.liferay.account.model.AccountGroup;
-import com.liferay.account.service.AccountEntryLocalService;
-import com.liferay.account.service.AccountGroupLocalService;
-import com.liferay.account.service.AccountRoleLocalService;
+import com.liferay.dispatch.model.DispatchTrigger;
+import com.liferay.dispatch.service.DispatchTriggerLocalService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -30,33 +28,26 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Drew Brokke
+ * @author Jorge Díaz
  */
 @Component(immediate = true, service = ModelListener.class)
 public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterRemove(Company company) throws ModelListenerException {
-		_accountRoleLocalService.deleteAccountRolesByCompanyId(
-			company.getCompanyId());
-
 		try {
-			_deleteAccountGroups(company);
+			_deleteDispatchTriggers(company);
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);
 		}
 	}
 
-	@Override
-	public void onBeforeRemove(Company company) throws ModelListenerException {
-		_accountEntryLocalService.deleteAccountEntriesByCompanyId(
-			company.getCompanyId());
-	}
+	private void _deleteDispatchTriggers(Company company)
+		throws PortalException {
 
-	private void _deleteAccountGroups(Company company) throws PortalException {
 		ActionableDynamicQuery actionableDynamicQuery =
-			_accountGroupLocalService.getActionableDynamicQuery();
+			_dispatchTriggerLocalService.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> dynamicQuery.add(
@@ -64,19 +55,14 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 					"companyId", company.getCompanyId())));
 
 		actionableDynamicQuery.setPerformActionMethod(
-			accountGroup -> _accountGroupLocalService.deleteAccountGroup(
-				(AccountGroup)accountGroup));
+			dispatchTrigger ->
+				_dispatchTriggerLocalService.deleteDispatchTrigger(
+					(DispatchTrigger)dispatchTrigger));
 
 		actionableDynamicQuery.performActions();
 	}
 
 	@Reference
-	private AccountEntryLocalService _accountEntryLocalService;
-
-	@Reference
-	private AccountGroupLocalService _accountGroupLocalService;
-
-	@Reference
-	private AccountRoleLocalService _accountRoleLocalService;
+	private DispatchTriggerLocalService _dispatchTriggerLocalService;
 
 }

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.scheduler.SchedulerException;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalRunMode;
@@ -94,7 +95,9 @@ public class DispatchTriggerLocalServiceImpl
 			DispatchTrigger dispatchTrigger)
 		throws PortalException {
 
-		if (dispatchTrigger.isSystem() && !PortalRunMode.isTestMode()) {
+		if (dispatchTrigger.isSystem() && !PortalRunMode.isTestMode() &&
+			!CompanyThreadLocal.isDeleteInProcess()) {
+
 			return dispatchTrigger;
 		}
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/CompanyModelListener.java
@@ -12,12 +12,10 @@
  * details.
  */
 
-package com.liferay.account.internal.model.listener;
+package com.liferay.document.library.internal.model.listener;
 
-import com.liferay.account.model.AccountGroup;
-import com.liferay.account.service.AccountEntryLocalService;
-import com.liferay.account.service.AccountGroupLocalService;
-import com.liferay.account.service.AccountRoleLocalService;
+import com.liferay.document.library.model.DLStorageQuota;
+import com.liferay.document.library.service.DLStorageQuotaLocalService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -30,33 +28,26 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Drew Brokke
+ * @author Jorge Díaz
  */
 @Component(immediate = true, service = ModelListener.class)
 public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterRemove(Company company) throws ModelListenerException {
-		_accountRoleLocalService.deleteAccountRolesByCompanyId(
-			company.getCompanyId());
-
 		try {
-			_deleteAccountGroups(company);
+			_deleteDLStorageQuotas(company);
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);
 		}
 	}
 
-	@Override
-	public void onBeforeRemove(Company company) throws ModelListenerException {
-		_accountEntryLocalService.deleteAccountEntriesByCompanyId(
-			company.getCompanyId());
-	}
+	private void _deleteDLStorageQuotas(Company company)
+		throws PortalException {
 
-	private void _deleteAccountGroups(Company company) throws PortalException {
 		ActionableDynamicQuery actionableDynamicQuery =
-			_accountGroupLocalService.getActionableDynamicQuery();
+			_dlStorageQuotaLocalService.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> dynamicQuery.add(
@@ -64,19 +55,13 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 					"companyId", company.getCompanyId())));
 
 		actionableDynamicQuery.setPerformActionMethod(
-			accountGroup -> _accountGroupLocalService.deleteAccountGroup(
-				(AccountGroup)accountGroup));
+			dlStorageQuota -> _dlStorageQuotaLocalService.deleteDLStorageQuota(
+				(DLStorageQuota)dlStorageQuota));
 
 		actionableDynamicQuery.performActions();
 	}
 
 	@Reference
-	private AccountEntryLocalService _accountEntryLocalService;
-
-	@Reference
-	private AccountGroupLocalService _accountGroupLocalService;
-
-	@Reference
-	private AccountRoleLocalService _accountRoleLocalService;
+	private DLStorageQuotaLocalService _dlStorageQuotaLocalService;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLStorageQuotaDLFileVersionModelListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLStorageQuotaDLFileVersionModelListener.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -44,6 +45,10 @@ public class DLStorageQuotaDLFileVersionModelListener
 	@Override
 	public void onAfterRemove(DLFileVersion dlFileVersion)
 		throws ModelListenerException {
+
+		if (CompanyThreadLocal.isDeleteInProcess()) {
+			return;
+		}
 
 		_dlStorageQuotaLocalService.incrementStorageSize(
 			dlFileVersion.getCompanyId(), -dlFileVersion.getSize());

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/service/impl/DLStorageQuotaLocalServiceImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/service/impl/DLStorageQuotaLocalServiceImpl.java
@@ -52,7 +52,16 @@ public class DLStorageQuotaLocalServiceImpl
 	@BufferedIncrement(incrementClass = NumberIncrement.class)
 	@Override
 	public void incrementStorageSize(long companyId, long increment) {
-		DLStorageQuota dlStorageQuota = _getDLStorageQuota(companyId);
+		DLStorageQuota dlStorageQuota =
+			dlStorageQuotaPersistence.fetchByCompanyId(companyId);
+
+		if (dlStorageQuota == null) {
+			if (increment <= 0) {
+				return;
+			}
+
+			dlStorageQuota = _getDLStorageQuota(companyId);
+		}
 
 		dlStorageQuota.setStorageSize(
 			dlStorageQuota.getStorageSize() + increment);

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -163,9 +163,6 @@ public class FriendlyURLEntryLocalServiceImpl
 	public FriendlyURLEntry deleteFriendlyURLEntry(
 		FriendlyURLEntry friendlyURLEntry) {
 
-		friendlyURLEntryLocalizationPersistence.removeByFriendlyURLEntryId(
-			friendlyURLEntry.getFriendlyURLEntryId());
-
 		FriendlyURLEntry deletedFriendlyURLEntry =
 			friendlyURLEntryPersistence.remove(friendlyURLEntry);
 
@@ -232,9 +229,6 @@ public class FriendlyURLEntryLocalServiceImpl
 				groupId, classNameId, classPK);
 
 		for (FriendlyURLEntry friendlyURLEntry : friendlyURLEntries) {
-			friendlyURLEntryLocalizationPersistence.removeByFriendlyURLEntryId(
-				friendlyURLEntry.getFriendlyURLEntryId());
-
 			friendlyURLEntryPersistence.remove(friendlyURLEntry);
 		}
 

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/persistence/impl/FriendlyURLEntryPersistenceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/persistence/impl/FriendlyURLEntryPersistenceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.model.FriendlyURLEntryTable;
 import com.liferay.friendly.url.model.impl.FriendlyURLEntryImpl;
 import com.liferay.friendly.url.model.impl.FriendlyURLEntryModelImpl;
+import com.liferay.friendly.url.service.persistence.FriendlyURLEntryLocalizationPersistence;
 import com.liferay.friendly.url.service.persistence.FriendlyURLEntryPersistence;
 import com.liferay.friendly.url.service.persistence.impl.constants.FURLPersistenceConstants;
 import com.liferay.petra.string.StringBundler;
@@ -2298,6 +2299,9 @@ public class FriendlyURLEntryPersistenceImpl
 
 	@Override
 	protected FriendlyURLEntry removeImpl(FriendlyURLEntry friendlyURLEntry) {
+		friendlyURLEntryLocalizationPersistence.removeByFriendlyURLEntryId(
+			friendlyURLEntry.getFriendlyURLEntryId());
+
 		Session session = null;
 
 		try {
@@ -3018,6 +3022,10 @@ public class FriendlyURLEntryPersistenceImpl
 
 	@Reference
 	protected FinderCache finderCache;
+
+	@Reference
+	protected FriendlyURLEntryLocalizationPersistence
+		friendlyURLEntryLocalizationPersistence;
 
 	private static final String _SQL_SELECT_FRIENDLYURLENTRY =
 		"SELECT friendlyURLEntry FROM FriendlyURLEntry friendlyURLEntry";

--- a/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/model/listener/UserModelListener.java
+++ b/modules/apps/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/model/listener/UserModelListener.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Michael C. Han
  */
-@Component(enabled = false, immediate = true, service = ModelListener.class)
+@Component(immediate = true, service = ModelListener.class)
 public class UserModelListener extends BaseModelListener<User> {
 
 	@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/model/listener/CompanyModelListener.java
@@ -12,12 +12,11 @@
  * details.
  */
 
-package com.liferay.account.internal.model.listener;
+package com.liferay.oauth2.provider.internal.model.listener;
 
-import com.liferay.account.model.AccountGroup;
-import com.liferay.account.service.AccountEntryLocalService;
-import com.liferay.account.service.AccountGroupLocalService;
-import com.liferay.account.service.AccountRoleLocalService;
+import com.liferay.oauth2.provider.model.OAuth2ScopeGrant;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -30,33 +29,28 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Drew Brokke
+ * @author Jorge Díaz
  */
 @Component(immediate = true, service = ModelListener.class)
 public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterRemove(Company company) throws ModelListenerException {
-		_accountRoleLocalService.deleteAccountRolesByCompanyId(
-			company.getCompanyId());
-
 		try {
-			_deleteAccountGroups(company);
+			_oAuth2ApplicationLocalService.deleteOAuth2Applications(
+				company.getCompanyId());
+			_deleteOAuth2ScopeGrant(company);
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);
 		}
 	}
 
-	@Override
-	public void onBeforeRemove(Company company) throws ModelListenerException {
-		_accountEntryLocalService.deleteAccountEntriesByCompanyId(
-			company.getCompanyId());
-	}
+	private void _deleteOAuth2ScopeGrant(Company company)
+		throws PortalException {
 
-	private void _deleteAccountGroups(Company company) throws PortalException {
 		ActionableDynamicQuery actionableDynamicQuery =
-			_accountGroupLocalService.getActionableDynamicQuery();
+			_oAuth2ScopeGrantLocalService.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> dynamicQuery.add(
@@ -64,19 +58,17 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 					"companyId", company.getCompanyId())));
 
 		actionableDynamicQuery.setPerformActionMethod(
-			accountGroup -> _accountGroupLocalService.deleteAccountGroup(
-				(AccountGroup)accountGroup));
+			oAuth2ScopeGrant ->
+				_oAuth2ScopeGrantLocalService.deleteOAuth2ScopeGrant(
+					(OAuth2ScopeGrant)oAuth2ScopeGrant));
 
 		actionableDynamicQuery.performActions();
 	}
 
 	@Reference
-	private AccountEntryLocalService _accountEntryLocalService;
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	@Reference
-	private AccountGroupLocalService _accountGroupLocalService;
-
-	@Reference
-	private AccountRoleLocalService _accountRoleLocalService;
+	private OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
 
 }

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/service/test/GroupServiceTest.java
@@ -53,6 +53,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.DBAssertionUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
@@ -215,6 +216,9 @@ public class GroupServiceTest {
 				"preferences that do no belong to a single layout",
 			_portletPreferencesLocalService.fetchPortletPreferences(
 				portletPreferences.getPortletPreferencesId()));
+
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"groupId", group.getGroupId());
 	}
 
 	@Test(expected = NoSuchResourcePermissionException.class)
@@ -238,6 +242,12 @@ public class GroupServiceTest {
 			stagingGroup.getCompanyId(), Group.class.getName(),
 			ResourceConstants.SCOPE_INDIVIDUAL,
 			String.valueOf(stagingGroup.getGroupId()), role.getRoleId());
+
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"groupId", group.getGroupId());
+
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"groupId", stagingGroup.getGroupId());
 	}
 
 	@Test
@@ -269,6 +279,12 @@ public class GroupServiceTest {
 		stagingUserGroupRolesCount = stagingUserGroupRoles.size();
 
 		Assert.assertEquals(0, stagingUserGroupRolesCount);
+
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"groupId", group.getGroupId());
+
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"groupId", stagingGroup.getGroupId());
 	}
 
 	@Test
@@ -312,6 +328,9 @@ public class GroupServiceTest {
 
 			_organizationLocalService.deleteOrganization(organization);
 		}
+
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"groupId", organizationSite.getGroupId());
 	}
 
 	@Test
@@ -337,6 +356,9 @@ public class GroupServiceTest {
 		Assert.assertEquals(
 			initialTagsCount,
 			_assetTagLocalService.getGroupTagsCount(group.getGroupId()));
+
+		DBAssertionUtil.assertTablesWithInvalidRecords(
+			"groupId", group.getGroupId());
 	}
 
 	@Test

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/LVEntryLocalServiceBaseImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/base/LVEntryLocalServiceBaseImpl.java
@@ -1413,28 +1413,16 @@ public abstract class LVEntryLocalServiceBaseImpl
 		@Override
 		public void afterDelete(LVEntry publishedLVEntry)
 			throws PortalException {
-
-			lvEntryLocalizationPersistence.removeByLvEntryId(
-				publishedLVEntry.getPrimaryKey());
-			lvEntryLocalizationVersionPersistence.removeByLvEntryId(
-				publishedLVEntry.getPrimaryKey());
 		}
 
 		@Override
 		public void afterDeleteDraft(LVEntry draftLVEntry)
 			throws PortalException {
-
-			lvEntryLocalizationPersistence.removeByLvEntryId(
-				draftLVEntry.getPrimaryKey());
 		}
 
 		@Override
 		public void afterDeleteVersion(LVEntryVersion lvEntryVersion)
 			throws PortalException {
-
-			lvEntryLocalizationVersionPersistence.removeByLvEntryId_Version(
-				lvEntryVersion.getVersionedModelId(),
-				lvEntryVersion.getVersion());
 		}
 
 		@Override

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LVEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LVEntryPersistenceImpl.java
@@ -44,6 +44,7 @@ import com.liferay.portal.tools.service.builder.test.model.LVEntryTable;
 import com.liferay.portal.tools.service.builder.test.model.impl.LVEntryImpl;
 import com.liferay.portal.tools.service.builder.test.model.impl.LVEntryModelImpl;
 import com.liferay.portal.tools.service.builder.test.service.persistence.BigDecimalEntryPersistence;
+import com.liferay.portal.tools.service.builder.test.service.persistence.LVEntryLocalizationPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.LVEntryPersistence;
 
 import java.io.Serializable;
@@ -6153,6 +6154,9 @@ public class LVEntryPersistenceImpl
 		lvEntryToBigDecimalEntryTableMapper.deleteLeftPrimaryKeyTableMappings(
 			lvEntry.getPrimaryKey());
 
+		lvEntryLocalizationPersistence.removeByLvEntryId(
+			lvEntry.getLvEntryId());
+
 		Session session = null;
 
 		try {
@@ -7087,6 +7091,9 @@ public class LVEntryPersistenceImpl
 		<LVEntry,
 		 com.liferay.portal.tools.service.builder.test.model.BigDecimalEntry>
 			lvEntryToBigDecimalEntryTableMapper;
+
+	@BeanReference(type = LVEntryLocalizationPersistence.class)
+	protected LVEntryLocalizationPersistence lvEntryLocalizationPersistence;
 
 	private static final String _SQL_SELECT_LVENTRY =
 		"SELECT lvEntry FROM LVEntry lvEntry";

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LVEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LVEntryPersistenceImpl.java
@@ -45,6 +45,7 @@ import com.liferay.portal.tools.service.builder.test.model.impl.LVEntryImpl;
 import com.liferay.portal.tools.service.builder.test.model.impl.LVEntryModelImpl;
 import com.liferay.portal.tools.service.builder.test.service.persistence.BigDecimalEntryPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.LVEntryLocalizationPersistence;
+import com.liferay.portal.tools.service.builder.test.service.persistence.LVEntryLocalizationVersionPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.LVEntryPersistence;
 
 import java.io.Serializable;
@@ -6157,6 +6158,9 @@ public class LVEntryPersistenceImpl
 		lvEntryLocalizationPersistence.removeByLvEntryId(
 			lvEntry.getLvEntryId());
 
+		lvEntryLocalizationVersionPersistence.removeByLvEntryId(
+			lvEntry.getLvEntryId());
+
 		Session session = null;
 
 		try {
@@ -7094,6 +7098,10 @@ public class LVEntryPersistenceImpl
 
 	@BeanReference(type = LVEntryLocalizationPersistence.class)
 	protected LVEntryLocalizationPersistence lvEntryLocalizationPersistence;
+
+	@BeanReference(type = LVEntryLocalizationVersionPersistence.class)
+	protected LVEntryLocalizationVersionPersistence
+		lvEntryLocalizationVersionPersistence;
 
 	private static final String _SQL_SELECT_LVENTRY =
 		"SELECT lvEntry FROM LVEntry lvEntry";

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LVEntryVersionPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LVEntryVersionPersistenceImpl.java
@@ -41,6 +41,7 @@ import com.liferay.portal.tools.service.builder.test.model.LVEntryVersionTable;
 import com.liferay.portal.tools.service.builder.test.model.impl.LVEntryVersionImpl;
 import com.liferay.portal.tools.service.builder.test.model.impl.LVEntryVersionModelImpl;
 import com.liferay.portal.tools.service.builder.test.service.persistence.BigDecimalEntryPersistence;
+import com.liferay.portal.tools.service.builder.test.service.persistence.LVEntryLocalizationVersionPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.LVEntryVersionPersistence;
 
 import java.io.Serializable;
@@ -6101,6 +6102,9 @@ public class LVEntryVersionPersistenceImpl
 		lvEntryVersionToBigDecimalEntryTableMapper.
 			deleteLeftPrimaryKeyTableMappings(lvEntryVersion.getPrimaryKey());
 
+		lvEntryLocalizationVersionPersistence.removeByLvEntryId_Version(
+			lvEntryVersion.getVersionedModelId(), lvEntryVersion.getVersion());
+
 		Session session = null;
 
 		try {
@@ -7048,6 +7052,10 @@ public class LVEntryVersionPersistenceImpl
 		<LVEntryVersion,
 		 com.liferay.portal.tools.service.builder.test.model.BigDecimalEntry>
 			lvEntryVersionToBigDecimalEntryTableMapper;
+
+	@BeanReference(type = LVEntryLocalizationVersionPersistence.class)
+	protected LVEntryLocalizationVersionPersistence
+		lvEntryLocalizationVersionPersistence;
 
 	private static final String _SQL_SELECT_LVENTRYVERSION =
 		"SELECT lvEntryVersion FROM LVEntryVersion lvEntryVersion";

--- a/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LocalizedEntryPersistenceImpl.java
+++ b/modules/util/portal-tools-service-builder-test-service/src/main/java/com/liferay/portal/tools/service/builder/test/service/persistence/impl/LocalizedEntryPersistenceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.tools.service.builder.test.service.persistence.impl;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.FinderPath;
@@ -31,6 +32,7 @@ import com.liferay.portal.tools.service.builder.test.model.LocalizedEntry;
 import com.liferay.portal.tools.service.builder.test.model.LocalizedEntryTable;
 import com.liferay.portal.tools.service.builder.test.model.impl.LocalizedEntryImpl;
 import com.liferay.portal.tools.service.builder.test.model.impl.LocalizedEntryModelImpl;
+import com.liferay.portal.tools.service.builder.test.service.persistence.LocalizedEntryLocalizationPersistence;
 import com.liferay.portal.tools.service.builder.test.service.persistence.LocalizedEntryPersistence;
 
 import java.io.Serializable;
@@ -224,6 +226,9 @@ public class LocalizedEntryPersistenceImpl
 
 	@Override
 	protected LocalizedEntry removeImpl(LocalizedEntry localizedEntry) {
+		localizedEntryLocalizationPersistence.removeByLocalizedEntryId(
+			localizedEntry.getLocalizedEntryId());
+
 		Session session = null;
 
 		try {
@@ -564,6 +569,10 @@ public class LocalizedEntryPersistenceImpl
 
 	@ServiceReference(type = FinderCache.class)
 	protected FinderCache finderCache;
+
+	@BeanReference(type = LocalizedEntryLocalizationPersistence.class)
+	protected LocalizedEntryLocalizationPersistence
+		localizedEntryLocalizationPersistence;
 
 	private static final String _SQL_SELECT_LOCALIZEDENTRY =
 		"SELECT localizedEntry FROM LocalizedEntry localizedEntry";

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -179,6 +179,16 @@ import org.osgi.service.component.annotations.Reference;
 	</#if>
 </#list>
 
+<#if entity.localizedEntity??>
+	<#assign
+		referenceEntity = serviceBuilder.getEntity(entity.localizedEntity.name)
+	/>
+
+	<#if referenceEntity.hasPersistence()>
+		import ${referenceEntity.apiPackagePath}.service.persistence.${referenceEntity.name}Persistence;
+	</#if>
+</#if>
+
 /**
  * The persistence implementation for the ${entity.humanName} service.
  *
@@ -688,6 +698,15 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 				${entity.variableName}To${referenceEntity.name}TableMapper.deleteLeftPrimaryKeyTableMappings(${entity.variableName}.getPrimaryKey());
 			</#if>
 		</#list>
+
+		<#if entity.localizedEntity??>
+			<#assign
+				localizedEntity = entity.localizedEntity
+				pkEntityColumn = entity.PKEntityColumns?first
+			/>
+
+			${localizedEntity.variableName}Persistence.removeBy${pkEntityColumn.methodName}(${entity.variableName}.get${pkEntityColumn.methodName}());
+		</#if>
 
 		Session session = null;
 
@@ -2863,6 +2882,24 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 			protected TableMapper<${entity.name}, ${referenceEntity.apiPackagePath}.model.${referenceEntity.name}> ${entity.variableName}To${referenceEntity.name}TableMapper;
 		</#if>
 	</#list>
+
+	<#if entity.localizedEntity??>
+		<#assign
+			referenceEntity = serviceBuilder.getEntity(entity.localizedEntity.name)
+		/>
+
+		<#if !dependencyInjectorDS || (referenceEntity.apiPackagePath == apiPackagePath)>
+			<#if dependencyInjectorDS>
+				@Reference
+			<#elseif osgiModule && (referenceEntity.apiPackagePath != apiPackagePath)>
+				@ServiceReference(type = ${referenceEntity.name}Persistence.class)
+			<#else>
+				@BeanReference(type = ${referenceEntity.name}Persistence.class)
+			</#if>
+
+			protected ${referenceEntity.name}Persistence ${referenceEntity.variableName}Persistence;
+		</#if>
+	</#if>
 
 	<#if entity.isHierarchicalTree()>
 		protected NestedSetsTreeManager<${entity.name}> nestedSetsTreeManager = new PersistenceNestedSetsTreeManager<${entity.name}>(this, "${entity.table}", "${entity.name}", ${entity.name}Impl.class, "${pkEntityColumn.DBName}", "${scopeEntityColumn.DBName}", "left${pkEntityColumn.methodName}", "right${pkEntityColumn.methodName}");

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -180,13 +180,9 @@ import org.osgi.service.component.annotations.Reference;
 </#list>
 
 <#if entity.localizedEntity??>
-	<#assign
-		referenceEntity = serviceBuilder.getEntity(entity.localizedEntity.name)
-	/>
+	<#assign localizedEntity = entity.localizedEntity />
 
-	<#if referenceEntity.hasPersistence()>
-		import ${referenceEntity.apiPackagePath}.service.persistence.${referenceEntity.name}Persistence;
-	</#if>
+	import ${apiPackagePath}.service.persistence.${localizedEntity.name}Persistence;
 </#if>
 
 /**
@@ -2884,21 +2880,15 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 	</#list>
 
 	<#if entity.localizedEntity??>
-		<#assign
-			referenceEntity = serviceBuilder.getEntity(entity.localizedEntity.name)
-		/>
+		<#assign localizedEntity = entity.localizedEntity />
 
-		<#if !dependencyInjectorDS || (referenceEntity.apiPackagePath == apiPackagePath)>
-			<#if dependencyInjectorDS>
-				@Reference
-			<#elseif osgiModule && (referenceEntity.apiPackagePath != apiPackagePath)>
-				@ServiceReference(type = ${referenceEntity.name}Persistence.class)
-			<#else>
-				@BeanReference(type = ${referenceEntity.name}Persistence.class)
-			</#if>
-
-			protected ${referenceEntity.name}Persistence ${referenceEntity.variableName}Persistence;
+		<#if dependencyInjectorDS>
+			@Reference
+		<#else>
+			@BeanReference(type = ${localizedEntity.name}Persistence.class)
 		</#if>
+
+		protected ${localizedEntity.name}Persistence ${localizedEntity.variableName}Persistence;
 	</#if>
 
 	<#if entity.isHierarchicalTree()>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -193,6 +193,15 @@ import org.osgi.service.component.annotations.Reference;
 	</#if>
 </#if>
 
+<#if entity.versionedEntity?? && entity.versionedEntity.localizedEntity??>
+	<#assign
+		versionedEntity = entity.versionedEntity
+		localizedVersionEntity = versionedEntity.localizedEntity.versionEntity
+	/>
+
+	import ${apiPackagePath}.service.persistence.${localizedVersionEntity.name}Persistence;
+</#if>
+
 /**
  * The persistence implementation for the ${entity.humanName} service.
  *
@@ -718,6 +727,16 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 
 				${localizedVersionEntity.variableName}Persistence.removeBy${pkEntityColumn.methodName}(${entity.variableName}.get${pkEntityColumn.methodName}());
 			</#if>
+		</#if>
+
+		<#if entity.versionedEntity?? && entity.versionedEntity.localizedEntity??>
+			<#assign
+				versionedEntity = entity.versionedEntity
+				localizedVersionEntity = versionedEntity.localizedEntity.versionEntity
+				pkEntityColumn = versionedEntity.PKEntityColumns?first
+			/>
+
+			${localizedVersionEntity.variableName}Persistence.removeBy${pkEntityColumn.methodName}_Version(${entity.variableName}.getVersionedModelId(), ${entity.variableName}.getVersion());
 		</#if>
 
 		Session session = null;
@@ -2917,6 +2936,21 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 
 			protected ${localizedVersionEntity.name}Persistence ${localizedVersionEntity.variableName}Persistence;
 		</#if>
+	</#if>
+
+	<#if entity.versionedEntity?? && entity.versionedEntity.localizedEntity??>
+		<#assign
+			versionedEntity = entity.versionedEntity
+			localizedVersionEntity = versionedEntity.localizedEntity.versionEntity
+		/>
+
+		<#if dependencyInjectorDS>
+			@Reference
+		<#else>
+			@BeanReference(type = ${localizedVersionEntity.name}Persistence.class)
+		</#if>
+
+		protected ${localizedVersionEntity.name}Persistence ${localizedVersionEntity.variableName}Persistence;
 	</#if>
 
 	<#if entity.isHierarchicalTree()>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -183,6 +183,14 @@ import org.osgi.service.component.annotations.Reference;
 	<#assign localizedEntity = entity.localizedEntity />
 
 	import ${apiPackagePath}.service.persistence.${localizedEntity.name}Persistence;
+
+	<#if localizedEntity.versionEntity??>
+		<#assign
+			localizedVersionEntity = localizedEntity.versionEntity
+		/>
+
+		import ${apiPackagePath}.service.persistence.${localizedVersionEntity.name}Persistence;
+	</#if>
 </#if>
 
 /**
@@ -702,6 +710,14 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 			/>
 
 			${localizedEntity.variableName}Persistence.removeBy${pkEntityColumn.methodName}(${entity.variableName}.get${pkEntityColumn.methodName}());
+
+			<#if localizedEntity.versionEntity??>
+				<#assign
+					localizedVersionEntity = localizedEntity.versionEntity
+				/>
+
+				${localizedVersionEntity.variableName}Persistence.removeBy${pkEntityColumn.methodName}(${entity.variableName}.get${pkEntityColumn.methodName}());
+			</#if>
 		</#if>
 
 		Session session = null;
@@ -2889,6 +2905,18 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 		</#if>
 
 		protected ${localizedEntity.name}Persistence ${localizedEntity.variableName}Persistence;
+
+		<#if localizedEntity.versionEntity??>
+			<#assign localizedVersionEntity = localizedEntity.versionEntity />
+
+			<#if dependencyInjectorDS>
+				@Reference
+			<#else>
+				@BeanReference(type = ${localizedVersionEntity.name}Persistence.class)
+			</#if>
+
+			protected ${localizedVersionEntity.name}Persistence ${localizedVersionEntity.variableName}Persistence;
+		</#if>
 	</#if>
 
 	<#if entity.isHierarchicalTree()>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/persistence_impl.ftl
@@ -40,6 +40,22 @@
 	<#assign useCache = "useFinderCache && productionMode" />
 </#if>
 
+<#if entity.localizedEntity??>
+	<#assign localizedEntity = entity.localizedEntity />
+
+	<#if localizedEntity.versionEntity??>
+		<#assign
+			localizedVersionEntity = localizedEntity.versionEntity
+		/>
+	</#if>
+</#if>
+
+<#if entity.versionedEntity?? && entity.versionedEntity.localizedEntity??>
+	<#assign
+		localizedVersionEntity = entity.versionedEntity.localizedEntity.versionEntity
+	/>
+</#if>
+
 package ${packagePath}.service.persistence.impl;
 
 import ${serviceBuilder.getCompatJavaClassName("StringBundler")};
@@ -179,26 +195,11 @@ import org.osgi.service.component.annotations.Reference;
 	</#if>
 </#list>
 
-<#if entity.localizedEntity??>
-	<#assign localizedEntity = entity.localizedEntity />
-
+<#if localizedEntity??>
 	import ${apiPackagePath}.service.persistence.${localizedEntity.name}Persistence;
-
-	<#if localizedEntity.versionEntity??>
-		<#assign
-			localizedVersionEntity = localizedEntity.versionEntity
-		/>
-
-		import ${apiPackagePath}.service.persistence.${localizedVersionEntity.name}Persistence;
-	</#if>
 </#if>
 
-<#if entity.versionedEntity?? && entity.versionedEntity.localizedEntity??>
-	<#assign
-		versionedEntity = entity.versionedEntity
-		localizedVersionEntity = versionedEntity.localizedEntity.versionEntity
-	/>
-
+<#if localizedVersionEntity??>
 	import ${apiPackagePath}.service.persistence.${localizedVersionEntity.name}Persistence;
 </#if>
 
@@ -712,31 +713,26 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 			</#if>
 		</#list>
 
-		<#if entity.localizedEntity??>
+		<#if localizedEntity??>
 			<#assign
-				localizedEntity = entity.localizedEntity
 				pkEntityColumn = entity.PKEntityColumns?first
 			/>
 
 			${localizedEntity.variableName}Persistence.removeBy${pkEntityColumn.methodName}(${entity.variableName}.get${pkEntityColumn.methodName}());
-
-			<#if localizedEntity.versionEntity??>
-				<#assign
-					localizedVersionEntity = localizedEntity.versionEntity
-				/>
-
-				${localizedVersionEntity.variableName}Persistence.removeBy${pkEntityColumn.methodName}(${entity.variableName}.get${pkEntityColumn.methodName}());
-			</#if>
 		</#if>
 
-		<#if entity.versionedEntity?? && entity.versionedEntity.localizedEntity??>
-			<#assign
-				versionedEntity = entity.versionedEntity
-				localizedVersionEntity = versionedEntity.localizedEntity.versionEntity
-				pkEntityColumn = versionedEntity.PKEntityColumns?first
-			/>
-
-			${localizedVersionEntity.variableName}Persistence.removeBy${pkEntityColumn.methodName}_Version(${entity.variableName}.getVersionedModelId(), ${entity.variableName}.getVersion());
+		<#if localizedVersionEntity??>
+			<#if entity.versionedEntity??>
+				<#assign
+					pkEntityColumn = entity.versionedEntity.PKEntityColumns?first
+				/>
+				${localizedVersionEntity.variableName}Persistence.removeBy${pkEntityColumn.methodName}_Version(${entity.variableName}.getVersionedModelId(), ${entity.variableName}.getVersion());
+			<#else>
+				<#assign
+					pkEntityColumn = entity.PKEntityColumns?first
+				/>
+				${localizedVersionEntity.variableName}Persistence.removeBy${pkEntityColumn.methodName}(${entity.variableName}.get${pkEntityColumn.methodName}());
+			</#if>
 		</#if>
 
 		Session session = null;
@@ -2914,9 +2910,7 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 		</#if>
 	</#list>
 
-	<#if entity.localizedEntity??>
-		<#assign localizedEntity = entity.localizedEntity />
-
+	<#if localizedEntity??>
 		<#if dependencyInjectorDS>
 			@Reference
 		<#else>
@@ -2924,26 +2918,9 @@ public class ${entity.name}PersistenceImpl extends BasePersistenceImpl<${entity.
 		</#if>
 
 		protected ${localizedEntity.name}Persistence ${localizedEntity.variableName}Persistence;
-
-		<#if localizedEntity.versionEntity??>
-			<#assign localizedVersionEntity = localizedEntity.versionEntity />
-
-			<#if dependencyInjectorDS>
-				@Reference
-			<#else>
-				@BeanReference(type = ${localizedVersionEntity.name}Persistence.class)
-			</#if>
-
-			protected ${localizedVersionEntity.name}Persistence ${localizedVersionEntity.variableName}Persistence;
-		</#if>
 	</#if>
 
-	<#if entity.versionedEntity?? && entity.versionedEntity.localizedEntity??>
-		<#assign
-			versionedEntity = entity.versionedEntity
-			localizedVersionEntity = versionedEntity.localizedEntity.versionEntity
-		/>
-
+	<#if localizedVersionEntity??>
 		<#if dependencyInjectorDS>
 			@Reference
 		<#else>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_base_impl.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_base_impl.ftl
@@ -2202,18 +2202,14 @@ import org.osgi.service.component.annotations.Reference;
 
 			@Override
 			public void afterDelete(${entity.name} published${entity.name}) throws PortalException {
-				${localizedEntity.variableName}Persistence.removeBy${pkEntityMethod}(published${entity.name}.getPrimaryKey());
-				${localizedVersionEntity.variableName}Persistence.removeBy${pkEntityMethod}(published${entity.name}.getPrimaryKey());
 			}
 
 			@Override
 			public void afterDeleteDraft(${entity.name} draft${entity.name}) throws PortalException {
-				${localizedEntity.variableName}Persistence.removeBy${pkEntityMethod}(draft${entity.name}.getPrimaryKey());
 			}
 
 			@Override
 			public void afterDeleteVersion(${versionEntity.name} ${versionEntity.variableName}) throws PortalException {
-				${localizedVersionEntity.variableName}Persistence.removeBy${pkEntityMethod}_Version(${versionEntity.variableName}.getVersionedModelId(), ${versionEntity.variableName}.getVersion());
 			}
 
 			@Override

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -191,6 +191,7 @@
 		<reference entity="Portlet" package-path="com.liferay.portal" />
 		<reference entity="Role" package-path="com.liferay.portal" />
 		<reference entity="SystemEvent" package-path="com.liferay.portal" />
+		<reference entity="Ticket" package-path="com.liferay.portal" />
 		<reference entity="User" package-path="com.liferay.portal" />
 		<reference entity="UserGroup" package-path="com.liferay.portal" />
 		<reference entity="VirtualHost" package-path="com.liferay.portal" />

--- a/portal-impl/src/com/liferay/portal/service/base/CompanyLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/CompanyLocalServiceBaseImpl.java
@@ -59,6 +59,7 @@ import com.liferay.portal.kernel.service.persistence.PortletPersistence;
 import com.liferay.portal.kernel.service.persistence.RoleFinder;
 import com.liferay.portal.kernel.service.persistence.RolePersistence;
 import com.liferay.portal.kernel.service.persistence.SystemEventPersistence;
+import com.liferay.portal.kernel.service.persistence.TicketPersistence;
 import com.liferay.portal.kernel.service.persistence.UserFinder;
 import com.liferay.portal.kernel.service.persistence.UserGroupFinder;
 import com.liferay.portal.kernel.service.persistence.UserGroupPersistence;
@@ -1184,6 +1185,47 @@ public abstract class CompanyLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the ticket local service.
+	 *
+	 * @return the ticket local service
+	 */
+	public com.liferay.portal.kernel.service.TicketLocalService
+		getTicketLocalService() {
+
+		return ticketLocalService;
+	}
+
+	/**
+	 * Sets the ticket local service.
+	 *
+	 * @param ticketLocalService the ticket local service
+	 */
+	public void setTicketLocalService(
+		com.liferay.portal.kernel.service.TicketLocalService
+			ticketLocalService) {
+
+		this.ticketLocalService = ticketLocalService;
+	}
+
+	/**
+	 * Returns the ticket persistence.
+	 *
+	 * @return the ticket persistence
+	 */
+	public TicketPersistence getTicketPersistence() {
+		return ticketPersistence;
+	}
+
+	/**
+	 * Sets the ticket persistence.
+	 *
+	 * @param ticketPersistence the ticket persistence
+	 */
+	public void setTicketPersistence(TicketPersistence ticketPersistence) {
+		this.ticketPersistence = ticketPersistence;
+	}
+
+	/**
 	 * Returns the user local service.
 	 *
 	 * @return the user local service
@@ -1579,6 +1621,15 @@ public abstract class CompanyLocalServiceBaseImpl
 
 	@BeanReference(type = SystemEventPersistence.class)
 	protected SystemEventPersistence systemEventPersistence;
+
+	@BeanReference(
+		type = com.liferay.portal.kernel.service.TicketLocalService.class
+	)
+	protected com.liferay.portal.kernel.service.TicketLocalService
+		ticketLocalService;
+
+	@BeanReference(type = TicketPersistence.class)
+	protected TicketPersistence ticketPersistence;
 
 	@BeanReference(
 		type = com.liferay.portal.kernel.service.UserLocalService.class

--- a/portal-impl/src/com/liferay/portal/service/base/CompanyServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/CompanyServiceBaseImpl.java
@@ -46,6 +46,7 @@ import com.liferay.portal.kernel.service.persistence.PortletPersistence;
 import com.liferay.portal.kernel.service.persistence.RoleFinder;
 import com.liferay.portal.kernel.service.persistence.RolePersistence;
 import com.liferay.portal.kernel.service.persistence.SystemEventPersistence;
+import com.liferay.portal.kernel.service.persistence.TicketPersistence;
 import com.liferay.portal.kernel.service.persistence.UserFinder;
 import com.liferay.portal.kernel.service.persistence.UserGroupFinder;
 import com.liferay.portal.kernel.service.persistence.UserGroupPersistence;
@@ -1129,6 +1130,47 @@ public abstract class CompanyServiceBaseImpl
 	}
 
 	/**
+	 * Returns the ticket local service.
+	 *
+	 * @return the ticket local service
+	 */
+	public com.liferay.portal.kernel.service.TicketLocalService
+		getTicketLocalService() {
+
+		return ticketLocalService;
+	}
+
+	/**
+	 * Sets the ticket local service.
+	 *
+	 * @param ticketLocalService the ticket local service
+	 */
+	public void setTicketLocalService(
+		com.liferay.portal.kernel.service.TicketLocalService
+			ticketLocalService) {
+
+		this.ticketLocalService = ticketLocalService;
+	}
+
+	/**
+	 * Returns the ticket persistence.
+	 *
+	 * @return the ticket persistence
+	 */
+	public TicketPersistence getTicketPersistence() {
+		return ticketPersistence;
+	}
+
+	/**
+	 * Sets the ticket persistence.
+	 *
+	 * @param ticketPersistence the ticket persistence
+	 */
+	public void setTicketPersistence(TicketPersistence ticketPersistence) {
+		this.ticketPersistence = ticketPersistence;
+	}
+
+	/**
 	 * Returns the user local service.
 	 *
 	 * @return the user local service
@@ -1618,6 +1660,15 @@ public abstract class CompanyServiceBaseImpl
 
 	@BeanReference(type = SystemEventPersistence.class)
 	protected SystemEventPersistence systemEventPersistence;
+
+	@BeanReference(
+		type = com.liferay.portal.kernel.service.TicketLocalService.class
+	)
+	protected com.liferay.portal.kernel.service.TicketLocalService
+		ticketLocalService;
+
+	@BeanReference(type = TicketPersistence.class)
+	protected TicketPersistence ticketPersistence;
 
 	@BeanReference(
 		type = com.liferay.portal.kernel.service.UserLocalService.class

--- a/portal-impl/src/com/liferay/portal/service/base/RegionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/RegionLocalServiceBaseImpl.java
@@ -145,11 +145,10 @@ public abstract class RegionLocalServiceBaseImpl
 	 *
 	 * @param region the region
 	 * @return the region that was removed
-	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	@Override
-	public Region deleteRegion(Region region) throws PortalException {
+	public Region deleteRegion(Region region) {
 		return regionPersistence.remove(region);
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -60,6 +60,7 @@ import com.liferay.portal.kernel.model.PortalPreferences;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.SystemEvent;
+import com.liferay.portal.kernel.model.Ticket;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.VirtualHost;
@@ -1418,6 +1419,21 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 					company.getCompanyId());
 
 		deleteSystemEventActionableDynamicQuery.performActions();
+
+		// Ticket
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			ticketLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> dynamicQuery.add(
+				RestrictionsFactoryUtil.eq(
+					"companyId", company.getCompanyId())));
+
+		actionableDynamicQuery.setPerformActionMethod(
+			(Ticket ticket) -> ticketLocalService.deleteTicket(ticket));
+
+		actionableDynamicQuery.performActions();
 
 		_deletePortalInstance(company);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CountryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CountryLocalServiceImpl.java
@@ -115,11 +115,6 @@ public class CountryLocalServiceImpl extends CountryLocalServiceBaseImpl {
 
 		addressLocalService.deleteCountryAddresses(country.getCountryId());
 
-		// Country localizations
-
-		countryLocalizationPersistence.removeByCountryId(
-			country.getCountryId());
-
 		// Organizations
 
 		_updateOrganizations(country.getCountryId());

--- a/portal-impl/src/com/liferay/portal/service/impl/CountryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CountryLocalServiceImpl.java
@@ -126,7 +126,7 @@ public class CountryLocalServiceImpl extends CountryLocalServiceBaseImpl {
 
 		// Regions
 
-		regionPersistence.removeByCountryId(country.getCountryId());
+		regionLocalService.deleteCountryRegions(country.getCountryId());
 
 		return country;
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -942,8 +942,6 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 				}
 			}
 
-			systemEventLocalService.deleteSystemEvents(group.getGroupId());
-
 			// Themes
 
 			ThemeLoader themeLoader =
@@ -1015,6 +1013,10 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 				workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
 					workflowDefinitionLink);
 			}
+
+			// System Events
+
+			systemEventLocalService.deleteSystemEvents(group.getGroupId());
 
 			// Group
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PortalPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortalPreferencesLocalServiceImpl.java
@@ -321,6 +321,8 @@ public class PortalPreferencesLocalServiceImpl
 					PortalPreferenceValue portalPreferenceValue =
 						portalPreferenceValuePersistence.create(++batchCounter);
 
+					portalPreferenceValue.setCompanyId(
+						portalPreferences.getCompanyId());
 					portalPreferenceValue.setPortalPreferencesId(
 						portalPreferences.getPortalPreferencesId());
 					portalPreferenceValue.setIndex(i);

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -101,7 +101,24 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 
 		// Organizations
 
-		_updateOrganizations(region.getRegionId());
+		ActionableDynamicQuery actionableDynamicQuery =
+			organizationLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property regionIdProperty = PropertyFactoryUtil.forName(
+					"regionId");
+
+				dynamicQuery.add(regionIdProperty.eq(region.getRegionId()));
+			});
+		actionableDynamicQuery.setPerformActionMethod(
+			(Organization organization) -> {
+				organization.setRegionId(0);
+
+				organizationLocalService.updateOrganization(organization);
+			});
+
+		actionableDynamicQuery.performActions();
 
 		return region;
 	}
@@ -201,27 +218,6 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 		if (Validator.isNull(name)) {
 			throw new RegionNameException();
 		}
-	}
-
-	private void _updateOrganizations(long regionId) throws PortalException {
-		ActionableDynamicQuery actionableDynamicQuery =
-			organizationLocalService.getActionableDynamicQuery();
-
-		actionableDynamicQuery.setAddCriteriaMethod(
-			dynamicQuery -> {
-				Property regionIdProperty = PropertyFactoryUtil.forName(
-					"regionId");
-
-				dynamicQuery.add(regionIdProperty.eq(regionId));
-			});
-		actionableDynamicQuery.setPerformActionMethod(
-			(Organization organization) -> {
-				organization.setRegionId(0);
-
-				organizationLocalService.updateOrganization(organization);
-			});
-
-		actionableDynamicQuery.performActions();
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.service.base.RegionLocalServiceBaseImpl;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -90,7 +89,7 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 
 		// Region Localizations
 
-		updateRegionLocalizations(region, Collections.emptyMap());
+		regionLocalizationPersistence.removeByRegionId(region.getRegionId());
 
 		// Region
 

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -14,15 +14,14 @@
 
 package com.liferay.portal.service.impl;
 
-import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
-import com.liferay.portal.kernel.dao.orm.Property;
-import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RegionCodeException;
 import com.liferay.portal.kernel.exception.RegionNameException;
 import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.OrganizationTable;
 import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -101,24 +100,21 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 
 		// Organizations
 
-		ActionableDynamicQuery actionableDynamicQuery =
-			organizationLocalService.getActionableDynamicQuery();
+		for (Organization organization :
+				organizationPersistence.<List<Organization>>dslQuery(
+					DSLQueryFactoryUtil.select(
+						OrganizationTable.INSTANCE
+					).from(
+						OrganizationTable.INSTANCE
+					).where(
+						OrganizationTable.INSTANCE.regionId.eq(
+							region.getRegionId())
+					))) {
 
-		actionableDynamicQuery.setAddCriteriaMethod(
-			dynamicQuery -> {
-				Property regionIdProperty = PropertyFactoryUtil.forName(
-					"regionId");
+			organization.setRegionId(0);
 
-				dynamicQuery.add(regionIdProperty.eq(region.getRegionId()));
-			});
-		actionableDynamicQuery.setPerformActionMethod(
-			(Organization organization) -> {
-				organization.setRegionId(0);
-
-				organizationLocalService.updateOrganization(organization);
-			});
-
-		actionableDynamicQuery.performActions();
+			organizationLocalService.updateOrganization(organization);
+		}
 
 		return region;
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -86,10 +86,6 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 	@Override
 	public Region deleteRegion(Region region) {
 
-		// Region Localizations
-
-		regionLocalizationPersistence.removeByRegionId(region.getRegionId());
-
 		// Region
 
 		regionPersistence.remove(region);

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -17,6 +17,7 @@ package com.liferay.portal.service.impl;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RegionCodeException;
 import com.liferay.portal.kernel.exception.RegionNameException;
@@ -29,6 +30,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.service.base.RegionLocalServiceBaseImpl;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -68,7 +70,12 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 
 	@Override
 	public void deleteCountryRegions(long countryId) {
-		regionPersistence.removeByCountryId(countryId);
+		for (Region region :
+				getRegions(
+					countryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+			deleteRegion(region);
+		}
 	}
 
 	@Override
@@ -80,6 +87,10 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 
 	@Override
 	public Region deleteRegion(Region region) throws PortalException {
+
+		// Region Localizations
+
+		updateRegionLocalizations(region, Collections.emptyMap());
 
 		// Region
 

--- a/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RegionLocalServiceImpl.java
@@ -84,7 +84,7 @@ public class RegionLocalServiceImpl extends RegionLocalServiceBaseImpl {
 	}
 
 	@Override
-	public Region deleteRegion(Region region) throws PortalException {
+	public Region deleteRegion(Region region) {
 
 		// Region Localizations
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/CountryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/CountryPersistenceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.service.persistence.impl;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
@@ -32,6 +33,7 @@ import com.liferay.portal.kernel.model.CountryTable;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.persistence.CountryLocalizationPersistence;
 import com.liferay.portal.kernel.service.persistence.CountryPersistence;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -5077,6 +5079,9 @@ public class CountryPersistenceImpl
 
 	@Override
 	protected Country removeImpl(Country country) {
+		countryLocalizationPersistence.removeByCountryId(
+			country.getCountryId());
+
 		Session session = null;
 
 		try {
@@ -5645,6 +5650,9 @@ public class CountryPersistenceImpl
 	public void destroy() {
 		EntityCacheUtil.removeCache(CountryImpl.class.getName());
 	}
+
+	@BeanReference(type = CountryLocalizationPersistence.class)
+	protected CountryLocalizationPersistence countryLocalizationPersistence;
 
 	private static final String _SQL_SELECT_COUNTRY =
 		"SELECT country FROM Country country";

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RegionPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RegionPersistenceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.service.persistence.impl;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.FinderCache;
@@ -32,6 +33,7 @@ import com.liferay.portal.kernel.model.RegionTable;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.persistence.RegionLocalizationPersistence;
 import com.liferay.portal.kernel.service.persistence.RegionPersistence;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -3116,6 +3118,8 @@ public class RegionPersistenceImpl
 
 	@Override
 	protected Region removeImpl(Region region) {
+		regionLocalizationPersistence.removeByRegionId(region.getRegionId());
+
 		Session session = null;
 
 		try {
@@ -3602,6 +3606,9 @@ public class RegionPersistenceImpl
 	public void destroy() {
 		EntityCacheUtil.removeCache(RegionImpl.class.getName());
 	}
+
+	@BeanReference(type = RegionLocalizationPersistence.class)
+	protected RegionLocalizationPersistence regionLocalizationPersistence;
 
 	private static final String _SQL_SELECT_REGION =
 		"SELECT region FROM Region region";

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalService.java
@@ -128,10 +128,9 @@ public interface RegionLocalService
 	 *
 	 * @param region the region
 	 * @return the region that was removed
-	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
-	public Region deleteRegion(Region region) throws PortalException;
+	public Region deleteRegion(Region region);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceUtil.java
@@ -126,9 +126,8 @@ public class RegionLocalServiceUtil {
 	 *
 	 * @param region the region
 	 * @return the region that was removed
-	 * @throws PortalException
 	 */
-	public static Region deleteRegion(Region region) throws PortalException {
+	public static Region deleteRegion(Region region) {
 		return getService().deleteRegion(region);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RegionLocalServiceWrapper.java
@@ -121,12 +121,10 @@ public class RegionLocalServiceWrapper
 	 *
 	 * @param region the region
 	 * @return the region that was removed
-	 * @throws PortalException
 	 */
 	@Override
 	public com.liferay.portal.kernel.model.Region deleteRegion(
-			com.liferay.portal.kernel.model.Region region)
-		throws com.liferay.portal.kernel.exception.PortalException {
+		com.liferay.portal.kernel.model.Region region) {
 
 		return _regionLocalService.deleteRegion(region);
 	}

--- a/portal-test/src/com/liferay/portal/kernel/test/util/DBAssertionUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/DBAssertionUtil.java
@@ -104,7 +104,7 @@ public class DBAssertionUtil {
 					String tableName = dbInspector.normalizeName(
 						tableResultSet.getString("TABLE_NAME"));
 
-					if (_ignoredTableNames.contains(tableName) ||
+					if (_ignoredTable(tableName) ||
 						!dbInspector.hasColumn(tableName, columnName)) {
 
 						continue;
@@ -136,6 +136,16 @@ public class DBAssertionUtil {
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			if (resultSet.next() && (resultSet.getInt(1) > 0)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static boolean _ignoredTable(String tableName) {
+		for (String ignoredTableName : _ignoredTableNames) {
+			if (StringUtil.equalsIgnoreCase(ignoredTableName, tableName)) {
 				return true;
 			}
 		}

--- a/portal-test/src/com/liferay/portal/kernel/test/util/DBAssertionUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/DBAssertionUtil.java
@@ -27,7 +27,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -102,7 +104,9 @@ public class DBAssertionUtil {
 					String tableName = dbInspector.normalizeName(
 						tableResultSet.getString("TABLE_NAME"));
 
-					if (!dbInspector.hasColumn(tableName, columnName)) {
+					if (_ignoredTableNames.contains(tableName) ||
+						!dbInspector.hasColumn(tableName, columnName)) {
+
 						continue;
 					}
 
@@ -138,5 +142,8 @@ public class DBAssertionUtil {
 
 		return false;
 	}
+
+	private static final Set<String> _ignoredTableNames = new HashSet<>(
+		Arrays.asList("Audit_AuditEvent"));
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/util/DBAssertionUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/DBAssertionUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.test.util;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -21,9 +22,13 @@ import com.liferay.portal.kernel.util.StringUtil;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.Assert;
@@ -64,6 +69,74 @@ public class DBAssertionUtil {
 
 		Assert.assertEquals(
 			columnNamesSet.toString(), 0, columnNamesSet.size());
+	}
+
+	public static void assertTablesWithInvalidRecords(
+			String columnName, long wrongValue)
+		throws Exception {
+
+		List<String> invalidTables = getTablesWithInvalidRecords(
+			columnName, wrongValue);
+
+		Assert.assertEquals(Collections.emptyList(), invalidTables);
+	}
+
+	protected static List<String> getTablesWithInvalidRecords(
+			String columnName, long wrongValue)
+		throws Exception {
+
+		List<String> invalidTables = new ArrayList<>();
+
+		try (Connection connection = DataAccess.getConnection()) {
+			DBInspector dbInspector = new DBInspector(connection);
+
+			String catalog = dbInspector.getCatalog();
+			String schema = dbInspector.getSchema();
+
+			DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+			try (ResultSet tableResultSet = databaseMetaData.getTables(
+					catalog, schema, null, new String[] {"TABLE"})) {
+
+				while (tableResultSet.next()) {
+					String tableName = dbInspector.normalizeName(
+						tableResultSet.getString("TABLE_NAME"));
+
+					if (!dbInspector.hasColumn(tableName, columnName)) {
+						continue;
+					}
+
+					if (hasInvalidRecords(
+							connection, tableName, columnName, wrongValue)) {
+
+						invalidTables.add(tableName);
+					}
+				}
+			}
+		}
+
+		return invalidTables;
+	}
+
+	protected static boolean hasInvalidRecords(
+			Connection connection, String tableName, String columnName,
+			long wrongValue)
+		throws SQLException {
+
+		String query = StringBundler.concat(
+			"select count(*) from ", tableName, " where ", columnName, " = ",
+			wrongValue);
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				query);
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next() && (resultSet.getInt(1) > 0)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.5.0
+version 3.6.0


### PR DESCRIPTION
- LPS-137974 Delete RegionLocalization records linked to the Region ones
- LPS-137974 Update tests: Add a RegionLocalization entry and check it is deleted when deleting a Country or a Region
- LPS-137974 Simplify.
- LPS-137974 Inline method with only one usage.
- LPS-137974 Use DSL.
- LPS-137974 Remove unnessesary throws.
- LPS-137974 Build Service.
- LPS-137974 Delete the localization records at service builder level in the removeImpl method of persistenceImpl classes
- LPS-137974 Remove unnecessary code in *LocalServiceImpl classes, the localized records deletion will be done by service builder
- LPS-137974 Regen services
- LPS-160 Add/update CompanyModelListener to delete AccountGroup, DispatchTrigger, DLStorageQuota, OAuth2Application and OAuth2ScopeGrant company records
- LPS-160 Delete Ticket records from deleted company
- LPS-160 Regen ant build-service-portal
- LPS-160 Delete the system dispacher trigger when we are deleting the company
- LPS-160 Don't create new DLStorageQuota records when we are deleting the company, also avoid regenerating the DLStorageQuota object with a negative value
- LPS-1 Check checkCompanyDeletion in CompanyLocalServiceTest
- LPS-1 Check checkCompanyDeletion in CompanyLocalServiceTest
- LPS-1 Move new assertTablesWithInvalidRecords method to DBAssertionUtil
- LPS-1 Semver
- LPS-1 Use assertTablesWithInvalidRecords in GroupServiceTest
- LPS-1 Exclude Audit_AuditEvent because it stores all the audit entries including from the deleted objects
- LPS-1 Avoid problems with databases with lowercase or uppercase table names
- LPS-1 Delete the records of UserNotificationEvent when deleting a user
