### PR TITLE
LPS-138761_3

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/AccountGroupModelListener.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/AccountGroupModelListener.java
@@ -20,6 +20,7 @@ import com.liferay.account.service.AccountGroupLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -32,6 +33,10 @@ public class AccountGroupModelListener extends BaseModelListener<AccountGroup> {
 
 	@Override
 	public void onAfterRemove(AccountGroup accountGroup) {
+		if (CompanyThreadLocal.isDeleteInProcess()) {
+			return;
+		}
+
 		if (accountGroup.isDefaultAccountGroup()) {
 			throw new ModelListenerException(
 				new DefaultAccountGroupException.

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/security/permission/contributor/AccountRoleContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/security/permission/contributor/AccountRoleContributor.java
@@ -53,10 +53,14 @@ public class AccountRoleContributor implements RoleContributor {
 			Group group = _groupLocalService.getGroup(
 				roleCollection.getGroupId());
 
+			User user = roleCollection.getUser();
+
+			if (group.getCompanyId() != user.getCompanyId()) {
+				return;
+			}
+
 			if (!Objects.equals(
 					AccountEntry.class.getName(), group.getClassName())) {
-
-				User user = roleCollection.getUser();
 
 				AccountEntry currentAccountEntry =
 					_currentAccountEntryManager.getCurrentAccountEntry(
@@ -76,8 +80,6 @@ public class AccountRoleContributor implements RoleContributor {
 				}
 			}
 			else {
-				User user = roleCollection.getUser();
-
 				if (_accountEntryUserRelLocalService.hasAccountEntryUserRel(
 						group.getClassPK(), user.getUserId())) {
 

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -21,8 +21,11 @@ import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalServiceUtil;
 import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.CompanyMxException;
 import com.liferay.portal.kernel.exception.CompanyNameException;
@@ -94,10 +97,20 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -187,6 +200,8 @@ public class CompanyLocalServiceTest {
 		for (String webId : PortalInstances.getWebIds()) {
 			Assert.assertNotEquals(companyWebId, webId);
 		}
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -231,6 +246,8 @@ public class CompanyLocalServiceTest {
 			"The company organization child group should delete with the " +
 				"company",
 			group);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -260,6 +277,8 @@ public class CompanyLocalServiceTest {
 			companyStagingGroup.getGroupId());
 
 		Assert.assertNull(companyStagingGroup);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -289,6 +308,8 @@ public class CompanyLocalServiceTest {
 			"test.xml", "", "", "test".getBytes(), null, null, serviceContext);
 
 		CompanyLocalServiceUtil.deleteCompany(companyId);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -335,6 +356,8 @@ public class CompanyLocalServiceTest {
 				layoutSetPrototype.getLayoutSetPrototypeId());
 
 		Assert.assertNull(layoutSetPrototype);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -373,6 +396,8 @@ public class CompanyLocalServiceTest {
 			});
 
 		CompanyLocalServiceUtil.deleteCompany(companyId);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -403,6 +428,8 @@ public class CompanyLocalServiceTest {
 		group = GroupLocalServiceUtil.fetchGroup(group.getGroupId());
 
 		Assert.assertNull(group);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -435,6 +462,8 @@ public class CompanyLocalServiceTest {
 			companyOrganizationGroup.getGroupId());
 
 		Assert.assertNull(companyOrganizationGroup);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -467,6 +496,8 @@ public class CompanyLocalServiceTest {
 		user = UserLocalServiceUtil.fetchUser(user.getUserId());
 
 		Assert.assertNull(user);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -515,6 +546,8 @@ public class CompanyLocalServiceTest {
 				user.getUserId(), group.getGroupId(), role.getRoleId()));
 
 		Assert.assertNull(UserLocalServiceUtil.fetchUser(user.getUserId()));
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test(expected = NoSuchPasswordPolicyException.class)
@@ -527,6 +560,8 @@ public class CompanyLocalServiceTest {
 
 		PasswordPolicyLocalServiceUtil.getDefaultPasswordPolicy(
 			company.getCompanyId());
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -544,6 +579,8 @@ public class CompanyLocalServiceTest {
 			company.getCompanyId(), GroupConstants.ANY_PARENT_GROUP_ID, false);
 
 		Assert.assertEquals(0, count);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -561,6 +598,8 @@ public class CompanyLocalServiceTest {
 			company.getCompanyId(), false);
 
 		Assert.assertEquals(0, count);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -575,6 +614,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertEquals(
 			layoutSetPrototypes.toString(), 0, layoutSetPrototypes.size());
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test(expected = NoSuchPasswordPolicyException.class)
@@ -598,6 +639,8 @@ public class CompanyLocalServiceTest {
 				}
 
 			});
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -611,6 +654,8 @@ public class CompanyLocalServiceTest {
 			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID);
 
 		Assert.assertEquals(0, count);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -623,6 +668,8 @@ public class CompanyLocalServiceTest {
 			companyId -> Assert.assertNotEquals(
 				"Company instance was not deleted", company.getCompanyId(),
 				(long)companyId));
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -649,6 +696,8 @@ public class CompanyLocalServiceTest {
 				}
 
 			});
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -672,6 +721,8 @@ public class CompanyLocalServiceTest {
 				}
 
 			});
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -684,6 +735,8 @@ public class CompanyLocalServiceTest {
 			company.getCompanyId());
 
 		Assert.assertEquals(roles.toString(), 0, roles.size());
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -725,6 +778,8 @@ public class CompanyLocalServiceTest {
 
 		Assert.assertEquals(UserGroupRole.class.getName(), list.get(0));
 		Assert.assertEquals(Role.class.getName(), list.get(1));
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -737,6 +792,8 @@ public class CompanyLocalServiceTest {
 			company.getCompanyId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		Assert.assertEquals(users.toString(), 0, users.size());
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test(expected = NoSuchVirtualHostException.class)
@@ -746,6 +803,8 @@ public class CompanyLocalServiceTest {
 		CompanyLocalServiceUtil.deleteCompany(company);
 
 		VirtualHostLocalServiceUtil.getVirtualHost(company.getWebId());
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test
@@ -755,6 +814,8 @@ public class CompanyLocalServiceTest {
 		Company company = addCompany();
 
 		CompanyLocalServiceUtil.deleteCompany(company);
+
+		assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 	}
 
 	@Test(expected = RequiredCompanyException.class)
@@ -978,6 +1039,20 @@ public class CompanyLocalServiceTest {
 			serviceContext);
 	}
 
+	protected void assertTablesWithInvalidRecords(
+			String columnName, long wrongValue)
+		throws Exception {
+
+		List<String> invalidTables = getTablesWithInvalidRecords(
+			columnName, wrongValue);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"There are tables with invalid ", columnName, "=", wrongValue,
+				" records"),
+			Collections.emptyList(), invalidTables);
+	}
+
 	protected ServiceContext getServiceContext(long companyId) {
 		ServiceContext serviceContext = new ServiceContext();
 
@@ -986,6 +1061,64 @@ public class CompanyLocalServiceTest {
 		serviceContext.setCompanyId(companyId);
 
 		return serviceContext;
+	}
+
+	protected List<String> getTablesWithInvalidRecords(
+			String columnName, long wrongValue)
+		throws Exception {
+
+		List<String> invalidTables = new ArrayList<>();
+
+		try (Connection connection = DataAccess.getConnection()) {
+			DBInspector dbInspector = new DBInspector(connection);
+
+			String catalog = dbInspector.getCatalog();
+			String schema = dbInspector.getSchema();
+
+			DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+			try (ResultSet tableResultSet = databaseMetaData.getTables(
+					catalog, schema, null, new String[] {"TABLE"})) {
+
+				while (tableResultSet.next()) {
+					String tableName = dbInspector.normalizeName(
+						tableResultSet.getString("TABLE_NAME"));
+
+					if (!dbInspector.hasColumn(tableName, columnName)) {
+						continue;
+					}
+
+					if (hasInvalidRecords(
+							connection, tableName, columnName, wrongValue)) {
+
+						invalidTables.add(tableName);
+					}
+				}
+			}
+		}
+
+		return invalidTables;
+	}
+
+	protected boolean hasInvalidRecords(
+			Connection connection, String tableName, String columnName,
+			long wrongValue)
+		throws SQLException {
+
+		String query = StringBundler.concat(
+			"select count(*) from ", tableName, " where ", columnName, " = ",
+			wrongValue);
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				query);
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next() && (resultSet.getInt(1) > 0)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	protected void testUpdateCompanyNames(
@@ -1060,6 +1193,8 @@ public class CompanyLocalServiceTest {
 		}
 		finally {
 			CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
+
+			assertTablesWithInvalidRecords("companyId", company.getCompanyId());
 
 			field.set(null, value);
 		}

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -1084,7 +1084,9 @@ public class CompanyLocalServiceTest {
 					String tableName = dbInspector.normalizeName(
 						tableResultSet.getString("TABLE_NAME"));
 
-					if (!dbInspector.hasColumn(tableName, columnName)) {
+					if (_ignoredTable(tableName) ||
+						!dbInspector.hasColumn(tableName, columnName)) {
+
 						continue;
 					}
 
@@ -1228,6 +1230,16 @@ public class CompanyLocalServiceTest {
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 	}
 
+	private boolean _ignoredTable(String tableName) {
+		for (String ignoredTableName : _ignoredTableNames) {
+			if (StringUtil.equalsIgnoreCase(ignoredTableName, tableName)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private List<String> _registerModelListeners() {
 		List<String> list = new CopyOnWriteArrayList<>();
 
@@ -1270,6 +1282,8 @@ public class CompanyLocalServiceTest {
 	private static final Log _log = LogFactoryUtil.getLog(
 		CompanyLocalServiceTest.class);
 
+	private static final Set<String> _ignoredTableNames = new HashSet<>(
+		Arrays.asList("Audit_AuditEvent"));
 	private static final TransactionConfig _transactionConfig;
 
 	static {

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/model/listener/CompanyModelListener.java
@@ -12,12 +12,10 @@
  * details.
  */
 
-package com.liferay.account.internal.model.listener;
+package com.liferay.dispatch.internal.model.listener;
 
-import com.liferay.account.model.AccountGroup;
-import com.liferay.account.service.AccountEntryLocalService;
-import com.liferay.account.service.AccountGroupLocalService;
-import com.liferay.account.service.AccountRoleLocalService;
+import com.liferay.dispatch.model.DispatchTrigger;
+import com.liferay.dispatch.service.DispatchTriggerLocalService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -30,33 +28,26 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Drew Brokke
+ * @author Jorge Díaz
  */
 @Component(immediate = true, service = ModelListener.class)
 public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterRemove(Company company) throws ModelListenerException {
-		_accountRoleLocalService.deleteAccountRolesByCompanyId(
-			company.getCompanyId());
-
 		try {
-			_deleteAccountGroups(company);
+			_deleteDispatchTriggers(company);
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);
 		}
 	}
 
-	@Override
-	public void onBeforeRemove(Company company) throws ModelListenerException {
-		_accountEntryLocalService.deleteAccountEntriesByCompanyId(
-			company.getCompanyId());
-	}
+	private void _deleteDispatchTriggers(Company company)
+		throws PortalException {
 
-	private void _deleteAccountGroups(Company company) throws PortalException {
 		ActionableDynamicQuery actionableDynamicQuery =
-			_accountGroupLocalService.getActionableDynamicQuery();
+			_dispatchTriggerLocalService.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> dynamicQuery.add(
@@ -64,19 +55,14 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 					"companyId", company.getCompanyId())));
 
 		actionableDynamicQuery.setPerformActionMethod(
-			accountGroup -> _accountGroupLocalService.deleteAccountGroup(
-				(AccountGroup)accountGroup));
+			dispatchTrigger ->
+				_dispatchTriggerLocalService.deleteDispatchTrigger(
+					(DispatchTrigger)dispatchTrigger));
 
 		actionableDynamicQuery.performActions();
 	}
 
 	@Reference
-	private AccountEntryLocalService _accountEntryLocalService;
-
-	@Reference
-	private AccountGroupLocalService _accountGroupLocalService;
-
-	@Reference
-	private AccountRoleLocalService _accountRoleLocalService;
+	private DispatchTriggerLocalService _dispatchTriggerLocalService;
 
 }

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.scheduler.SchedulerException;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalRunMode;
@@ -94,7 +95,9 @@ public class DispatchTriggerLocalServiceImpl
 			DispatchTrigger dispatchTrigger)
 		throws PortalException {
 
-		if (dispatchTrigger.isSystem() && !PortalRunMode.isTestMode()) {
+		if (dispatchTrigger.isSystem() && !PortalRunMode.isTestMode() &&
+			!CompanyThreadLocal.isDeleteInProcess()) {
+
 			return dispatchTrigger;
 		}
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/CompanyModelListener.java
@@ -12,12 +12,10 @@
  * details.
  */
 
-package com.liferay.account.internal.model.listener;
+package com.liferay.document.library.internal.model.listener;
 
-import com.liferay.account.model.AccountGroup;
-import com.liferay.account.service.AccountEntryLocalService;
-import com.liferay.account.service.AccountGroupLocalService;
-import com.liferay.account.service.AccountRoleLocalService;
+import com.liferay.document.library.model.DLStorageQuota;
+import com.liferay.document.library.service.DLStorageQuotaLocalService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -30,33 +28,26 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Drew Brokke
+ * @author Jorge Díaz
  */
 @Component(immediate = true, service = ModelListener.class)
 public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterRemove(Company company) throws ModelListenerException {
-		_accountRoleLocalService.deleteAccountRolesByCompanyId(
-			company.getCompanyId());
-
 		try {
-			_deleteAccountGroups(company);
+			_deleteDLStorageQuotas(company);
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);
 		}
 	}
 
-	@Override
-	public void onBeforeRemove(Company company) throws ModelListenerException {
-		_accountEntryLocalService.deleteAccountEntriesByCompanyId(
-			company.getCompanyId());
-	}
+	private void _deleteDLStorageQuotas(Company company)
+		throws PortalException {
 
-	private void _deleteAccountGroups(Company company) throws PortalException {
 		ActionableDynamicQuery actionableDynamicQuery =
-			_accountGroupLocalService.getActionableDynamicQuery();
+			_dlStorageQuotaLocalService.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> dynamicQuery.add(
@@ -64,19 +55,13 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 					"companyId", company.getCompanyId())));
 
 		actionableDynamicQuery.setPerformActionMethod(
-			accountGroup -> _accountGroupLocalService.deleteAccountGroup(
-				(AccountGroup)accountGroup));
+			dlStorageQuota -> _dlStorageQuotaLocalService.deleteDLStorageQuota(
+				(DLStorageQuota)dlStorageQuota));
 
 		actionableDynamicQuery.performActions();
 	}
 
 	@Reference
-	private AccountEntryLocalService _accountEntryLocalService;
-
-	@Reference
-	private AccountGroupLocalService _accountGroupLocalService;
-
-	@Reference
-	private AccountRoleLocalService _accountRoleLocalService;
+	private DLStorageQuotaLocalService _dlStorageQuotaLocalService;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLStorageQuotaDLFileVersionModelListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLStorageQuotaDLFileVersionModelListener.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -44,6 +45,10 @@ public class DLStorageQuotaDLFileVersionModelListener
 	@Override
 	public void onAfterRemove(DLFileVersion dlFileVersion)
 		throws ModelListenerException {
+
+		if (CompanyThreadLocal.isDeleteInProcess()) {
+			return;
+		}
 
 		_dlStorageQuotaLocalService.incrementStorageSize(
 			dlFileVersion.getCompanyId(), -dlFileVersion.getSize());

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/service/impl/DLStorageQuotaLocalServiceImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/service/impl/DLStorageQuotaLocalServiceImpl.java
@@ -52,7 +52,16 @@ public class DLStorageQuotaLocalServiceImpl
 	@BufferedIncrement(incrementClass = NumberIncrement.class)
 	@Override
 	public void incrementStorageSize(long companyId, long increment) {
-		DLStorageQuota dlStorageQuota = _getDLStorageQuota(companyId);
+		DLStorageQuota dlStorageQuota =
+			dlStorageQuotaPersistence.fetchByCompanyId(companyId);
+
+		if (dlStorageQuota == null) {
+			if (increment <= 0) {
+				return;
+			}
+
+			dlStorageQuota = _getDLStorageQuota(companyId);
+		}
 
 		dlStorageQuota.setStorageSize(
 			dlStorageQuota.getStorageSize() + increment);

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/model/listener/CompanyModelListener.java
@@ -12,12 +12,11 @@
  * details.
  */
 
-package com.liferay.account.internal.model.listener;
+package com.liferay.oauth2.provider.internal.model.listener;
 
-import com.liferay.account.model.AccountGroup;
-import com.liferay.account.service.AccountEntryLocalService;
-import com.liferay.account.service.AccountGroupLocalService;
-import com.liferay.account.service.AccountRoleLocalService;
+import com.liferay.oauth2.provider.model.OAuth2ScopeGrant;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -30,33 +29,28 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Drew Brokke
+ * @author Jorge Díaz
  */
 @Component(immediate = true, service = ModelListener.class)
 public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterRemove(Company company) throws ModelListenerException {
-		_accountRoleLocalService.deleteAccountRolesByCompanyId(
-			company.getCompanyId());
-
 		try {
-			_deleteAccountGroups(company);
+			_oAuth2ApplicationLocalService.deleteOAuth2Applications(
+				company.getCompanyId());
+			_deleteOAuth2ScopeGrant(company);
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);
 		}
 	}
 
-	@Override
-	public void onBeforeRemove(Company company) throws ModelListenerException {
-		_accountEntryLocalService.deleteAccountEntriesByCompanyId(
-			company.getCompanyId());
-	}
+	private void _deleteOAuth2ScopeGrant(Company company)
+		throws PortalException {
 
-	private void _deleteAccountGroups(Company company) throws PortalException {
 		ActionableDynamicQuery actionableDynamicQuery =
-			_accountGroupLocalService.getActionableDynamicQuery();
+			_oAuth2ScopeGrantLocalService.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> dynamicQuery.add(
@@ -64,19 +58,17 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 					"companyId", company.getCompanyId())));
 
 		actionableDynamicQuery.setPerformActionMethod(
-			accountGroup -> _accountGroupLocalService.deleteAccountGroup(
-				(AccountGroup)accountGroup));
+			oAuth2ScopeGrant ->
+				_oAuth2ScopeGrantLocalService.deleteOAuth2ScopeGrant(
+					(OAuth2ScopeGrant)oAuth2ScopeGrant));
 
 		actionableDynamicQuery.performActions();
 	}
 
 	@Reference
-	private AccountEntryLocalService _accountEntryLocalService;
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	@Reference
-	private AccountGroupLocalService _accountGroupLocalService;
-
-	@Reference
-	private AccountRoleLocalService _accountRoleLocalService;
+	private OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
 
 }


### PR DESCRIPTION
- LPS-138761 Reproduce bug in tests, checking that we have deleted all the company records in every table
- LPS-138761 Ignore Audit_AuditEvent table in the test, we shouldn't delete the audit information
- LPS-138761 Delete AccountGroup, DispatchTrigger, DLStorageQuota, OAuth2Application and OAuth2ScopeGrant deleted company records using model listeners
- LPS-138761 Delete the system dispacher trigger when we are deleting the company
- LPS-138761 Don't create new DLStorageQuota records when we are deleting the company, also avoid regenerating the DLStorageQuota object with a negative value
- LPS-138761 When creating a new instance, we have the omniadmin user from default company, in the CompanyLocalServiceTest the companyId threadlocal points to the new company so we create a wrong portalpreferences registry
