### PR TITLE
LPS-138761_7_check_test_1

### DIFF
--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -888,17 +888,16 @@ public class CompanyLocalServiceTest {
 	public void testUpdateInvalidCompanyNames() throws Exception {
 		Company company = addCompany();
 
-		Group group = GroupTestUtil.addGroup();
+		long companyId = company.getCompanyId();
 
-		group.setCompanyId(company.getCompanyId());
+		long userId = UserLocalServiceUtil.getDefaultUserId(companyId);
 
-		GroupLocalServiceUtil.updateGroup(group);
+		Group group = GroupTestUtil.addGroup(
+			companyId, userId, GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 		testUpdateCompanyNames(
 			company,
 			new String[] {StringPool.BLANK, group.getDescriptiveName()}, true);
-
-		GroupLocalServiceUtil.deleteGroup(group);
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 	}

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -65,6 +65,7 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.VirtualHostLocalServiceUtil;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
@@ -122,6 +123,7 @@ import org.springframework.mock.web.MockServletContext;
  * @author Mika Koivisto
  * @author Dale Shan
  */
+@DataGuard(autoDelete = false, scope = DataGuard.Scope.METHOD)
 @RunWith(Arquillian.class)
 @SybaseDumpTransactionLog(dumpBefore = {SybaseDump.CLASS, SybaseDump.METHOD})
 public class CompanyLocalServiceTest {

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -123,7 +123,10 @@ import org.springframework.mock.web.MockServletContext;
  * @author Mika Koivisto
  * @author Dale Shan
  */
-@DataGuard(autoDelete = false, scope = DataGuard.Scope.METHOD)
+@DataGuard(
+	autoDeleteClassNames = "com.liferay.portal.kernel.model.ClassName",
+	scope = DataGuard.Scope.METHOD
+)
 @RunWith(Arquillian.class)
 @SybaseDumpTransactionLog(dumpBefore = {SybaseDump.CLASS, SybaseDump.METHOD})
 public class CompanyLocalServiceTest {

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -380,9 +380,11 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 					companyId);
 		}
 
+		Long previousCompanyId = CompanyThreadLocal.getCompanyId();
 		boolean deleteInProcess = CompanyThreadLocal.isDeleteInProcess();
 
 		try {
+			CompanyThreadLocal.setCompanyId(companyId);
 			CompanyThreadLocal.setDeleteInProcess(true);
 
 			return doDeleteCompany(companyId);
@@ -395,6 +397,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			throw portalException;
 		}
 		finally {
+			CompanyThreadLocal.setCompanyId(previousCompanyId);
 			CompanyThreadLocal.setDeleteInProcess(deleteInProcess);
 		}
 	}

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuard.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuard.java
@@ -28,6 +28,8 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface DataGuard {
 
+	public boolean autoDelete() default true;
+
 	public Scope scope() default Scope.CLASS;
 
 	public enum Scope {

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuard.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuard.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface DataGuard {
 
-	public boolean autoDelete() default true;
+	public String[] autoDeleteClassNames() default "*";
 
 	public Scope scope() default Scope.CLASS;
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRule.java
@@ -34,7 +34,8 @@ public class DataGuardTestRule
 			return;
 		}
 
-		DataGuardTestRuleUtil.afterClass(dataBag, description.getClassName());
+		DataGuardTestRuleUtil.afterClass(
+			dataBag, description.getClassName(), _autoDelete(description));
 	}
 
 	@Override
@@ -47,7 +48,8 @@ public class DataGuardTestRule
 			return;
 		}
 
-		DataGuardTestRuleUtil.afterMethod(dataBag, description.getClassName());
+		DataGuardTestRuleUtil.afterMethod(
+			dataBag, description.getClassName(), _autoDelete(description));
 	}
 
 	@Override
@@ -83,6 +85,18 @@ public class DataGuardTestRule
 	}
 
 	private DataGuardTestRule() {
+	}
+
+	private boolean _autoDelete(Description description) {
+		Class<?> testClass = description.getTestClass();
+
+		DataGuard dataGuard = testClass.getAnnotation(DataGuard.class);
+
+		if (dataGuard == null) {
+			return true;
+		}
+
+		return dataGuard.autoDelete();
 	}
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRule.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.kernel.test.rule;
 
+import com.liferay.petra.string.StringPool;
+
 import org.junit.runner.Description;
 
 /**
@@ -35,7 +37,8 @@ public class DataGuardTestRule
 		}
 
 		DataGuardTestRuleUtil.afterClass(
-			dataBag, description.getClassName(), _autoDelete(description));
+			dataBag, description.getClassName(),
+			_autoDeleteClassNames(description));
 	}
 
 	@Override
@@ -49,7 +52,8 @@ public class DataGuardTestRule
 		}
 
 		DataGuardTestRuleUtil.afterMethod(
-			dataBag, description.getClassName(), _autoDelete(description));
+			dataBag, description.getClassName(),
+			_autoDeleteClassNames(description));
 	}
 
 	@Override
@@ -87,16 +91,16 @@ public class DataGuardTestRule
 	private DataGuardTestRule() {
 	}
 
-	private boolean _autoDelete(Description description) {
+	private String[] _autoDeleteClassNames(Description description) {
 		Class<?> testClass = description.getTestClass();
 
 		DataGuard dataGuard = testClass.getAnnotation(DataGuard.class);
 
 		if (dataGuard == null) {
-			return true;
+			return new String[] {StringPool.STAR};
 		}
 
-		return dataGuard.autoDelete();
+		return dataGuard.autoDeleteClassNames();
 	}
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -103,9 +103,7 @@ public class DataGuardTestRuleUtil {
 			DataBag dataBag, String testClassName, boolean autoDelete)
 		throws Throwable {
 
-		_autoDeleteAndAssert(
-			testClassName, dataBag._dataMap, dataBag._portlets,
-			dataBag._records, autoDelete);
+		afterClass(dataBag, testClassName, autoDelete);
 	}
 
 	public static DataBag beforeClass() {
@@ -127,9 +125,7 @@ public class DataGuardTestRuleUtil {
 	}
 
 	public static DataBag beforeMethod() {
-		return new DataBag(
-			_captureDataMap(), PortletLocalServiceUtil.getPortlets(), null,
-			null);
+		return beforeClass();
 	}
 
 	public static class DataBag {

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -608,6 +608,20 @@ public class DataGuardTestRuleUtil {
 	private static class RecordingSessionWrapper extends SessionWrapper {
 
 		@Override
+		public void delete(Object object) throws ORMException {
+			super.delete(object);
+
+			BaseModel<?> baseModel = (BaseModel<?>)object;
+
+			Map<Serializable, String> map = _records.get(
+				baseModel.getModelClassName());
+
+			if (map != null) {
+				map.remove(baseModel.getPrimaryKeyObj());
+			}
+		}
+
+		@Override
 		public Serializable save(Object object) throws ORMException {
 			_record(object);
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.registry.Registry;
@@ -74,11 +75,12 @@ public class DataGuardTestRuleUtil {
 	public static void afterClass(DataBag dataBag, String testClassName)
 		throws Throwable {
 
-		afterClass(dataBag, testClassName, true);
+		afterClass(dataBag, testClassName, new String[] {StringPool.STAR});
 	}
 
 	public static void afterClass(
-			DataBag dataBag, String testClassName, boolean autoDelete)
+			DataBag dataBag, String testClassName,
+			String[] autoDeleteClassNames)
 		throws Throwable {
 
 		ServiceRegistration<SessionCustomizer> serviceRegistration =
@@ -90,20 +92,21 @@ public class DataGuardTestRuleUtil {
 
 		_autoDeleteAndAssert(
 			testClassName, dataBag._dataMap, dataBag._portlets,
-			dataBag._records, autoDelete);
+			dataBag._records, autoDeleteClassNames);
 	}
 
 	public static void afterMethod(DataBag dataBag, String testClassName)
 		throws Throwable {
 
-		afterMethod(dataBag, testClassName, true);
+		afterMethod(dataBag, testClassName, new String[] {StringPool.STAR});
 	}
 
 	public static void afterMethod(
-			DataBag dataBag, String testClassName, boolean autoDelete)
+			DataBag dataBag, String testClassName,
+			String[] autoDeleteClassNames)
 		throws Throwable {
 
-		afterClass(dataBag, testClassName, autoDelete);
+		afterClass(dataBag, testClassName, autoDeleteClassNames);
 	}
 
 	public static DataBag beforeClass() {
@@ -153,7 +156,8 @@ public class DataGuardTestRuleUtil {
 			String testClassName,
 			Map<String, List<BaseModel<?>>> previousDataMap,
 			List<Portlet> previousPortlets,
-			Map<String, Map<Serializable, String>> records, boolean autoDelete)
+			Map<String, Map<Serializable, String>> records,
+			String[] autoDeleteClassNames)
 		throws Throwable {
 
 		for (Portlet portlet : PortletLocalServiceUtil.getPortlets()) {
@@ -162,9 +166,7 @@ public class DataGuardTestRuleUtil {
 			}
 		}
 
-		if (autoDelete) {
-			_autoDeleteLeftovers(previousDataMap);
-		}
+		_autoDeleteLeftovers(previousDataMap, autoDeleteClassNames);
 
 		StringBundler sb = new StringBundler();
 
@@ -224,8 +226,12 @@ public class DataGuardTestRuleUtil {
 	}
 
 	private static void _autoDeleteLeftovers(
-			Map<String, List<BaseModel<?>>> previousDataMap)
+			Map<String, List<BaseModel<?>>> previousDataMap,
+			String[] autoDeleteClassNames)
 		throws Throwable {
+
+		boolean autoDeleteAll = ArrayUtil.contains(
+			autoDeleteClassNames, StringPool.STAR);
 
 		Map<String, PersistedModelLocalService> persistedModelLocalServices =
 			_getPersistedModelLocalServices();
@@ -239,6 +245,12 @@ public class DataGuardTestRuleUtil {
 					dataMap.entrySet()) {
 
 				String className = entry.getKey();
+
+				if (!autoDeleteAll &&
+					!ArrayUtil.contains(autoDeleteClassNames, className)) {
+
+					continue;
+				}
 
 				PersistedModelLocalService persistedModelLocalService =
 					persistedModelLocalServices.get(className);

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -74,6 +74,13 @@ public class DataGuardTestRuleUtil {
 	public static void afterClass(DataBag dataBag, String testClassName)
 		throws Throwable {
 
+		afterClass(dataBag, testClassName, true);
+	}
+
+	public static void afterClass(
+			DataBag dataBag, String testClassName, boolean autoDelete)
+		throws Throwable {
+
 		ServiceRegistration<SessionCustomizer> serviceRegistration =
 			dataBag._serviceRegistration;
 
@@ -83,15 +90,22 @@ public class DataGuardTestRuleUtil {
 
 		_autoDeleteAndAssert(
 			testClassName, dataBag._dataMap, dataBag._portlets,
-			dataBag._records);
+			dataBag._records, autoDelete);
 	}
 
 	public static void afterMethod(DataBag dataBag, String testClassName)
 		throws Throwable {
 
+		afterMethod(dataBag, testClassName, true);
+	}
+
+	public static void afterMethod(
+			DataBag dataBag, String testClassName, boolean autoDelete)
+		throws Throwable {
+
 		_autoDeleteAndAssert(
 			testClassName, dataBag._dataMap, dataBag._portlets,
-			dataBag._records);
+			dataBag._records, autoDelete);
 	}
 
 	public static DataBag beforeClass() {
@@ -143,7 +157,7 @@ public class DataGuardTestRuleUtil {
 			String testClassName,
 			Map<String, List<BaseModel<?>>> previousDataMap,
 			List<Portlet> previousPortlets,
-			Map<String, Map<Serializable, String>> records)
+			Map<String, Map<Serializable, String>> records, boolean autoDelete)
 		throws Throwable {
 
 		for (Portlet portlet : PortletLocalServiceUtil.getPortlets()) {
@@ -152,7 +166,9 @@ public class DataGuardTestRuleUtil {
 			}
 		}
 
-		_autoDeleteLeftovers(previousDataMap);
+		if (autoDelete) {
+			_autoDeleteLeftovers(previousDataMap);
+		}
 
 		StringBundler sb = new StringBundler();
 


### PR DESCRIPTION
- LPS-138761 DataGuard: Make configurable the autoDelete functionality
- LPS-138761 DataGuard: Store stackthreads also with method scope
- LPS-138761 DataGuard: Remove the deleted objects from the _records map as we are not going to need it and we will save memory
- LPS-138761 DataGuard: Change the autoDelete flag to a className list to autoDelete this allow us to configure specific entities to be delete. Its default value is * that means it has to delete all of them
- LPS-138761 CompanyLocalServiceTest: Set DataGuard to autoDelete = false and method = scope to check we are correctly deleting all the created objects of the deleted company
- LPS-138761 CompanyLocalServiceTest: Create the group using the correct company and user
- LPS-138761 CompanyLocalServiceTest: Set the company thread local when creating a new company, it is not necessary to restore the old one because it is already handled in the setUp and tearDown methods
- LPS-138761 CompanyLocalServiceTest: Use the new autoDeleteClassNames
- LPS-138761 Set the companyId to be deleted in the company thread local during deletion to avoid problems with the audit and dl sync events that are created using the companyId from the thread local
