### PR TITLE
references_checker_CompanyLocalServiceTest_6

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/AccountGroupModelListener.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/model/listener/AccountGroupModelListener.java
@@ -20,6 +20,7 @@ import com.liferay.account.service.AccountGroupLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -32,6 +33,10 @@ public class AccountGroupModelListener extends BaseModelListener<AccountGroup> {
 
 	@Override
 	public void onAfterRemove(AccountGroup accountGroup) {
+		if (CompanyThreadLocal.isDeleteInProcess()) {
+			return;
+		}
+
 		if (accountGroup.isDefaultAccountGroup()) {
 			throw new ModelListenerException(
 				new DefaultAccountGroupException.

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/security/permission/contributor/AccountRoleContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/security/permission/contributor/AccountRoleContributor.java
@@ -53,10 +53,14 @@ public class AccountRoleContributor implements RoleContributor {
 			Group group = _groupLocalService.getGroup(
 				roleCollection.getGroupId());
 
+			User user = roleCollection.getUser();
+
+			if (group.getCompanyId() != user.getCompanyId()) {
+				return;
+			}
+
 			if (!Objects.equals(
 					AccountEntry.class.getName(), group.getClassName())) {
-
-				User user = roleCollection.getUser();
 
 				AccountEntry currentAccountEntry =
 					_currentAccountEntryManager.getCurrentAccountEntry(
@@ -76,8 +80,6 @@ public class AccountRoleContributor implements RoleContributor {
 				}
 			}
 			else {
-				User user = roleCollection.getUser();
-
 				if (_accountEntryUserRelLocalService.hasAccountEntryUserRel(
 						group.getClassPK(), user.getUserId())) {
 

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -891,17 +891,16 @@ public class CompanyLocalServiceTest {
 	public void testUpdateInvalidCompanyNames() throws Exception {
 		Company company = addCompany();
 
-		Group group = GroupTestUtil.addGroup();
+		long companyId = company.getCompanyId();
 
-		group.setCompanyId(company.getCompanyId());
+		long userId = UserLocalServiceUtil.getDefaultUserId(companyId);
 
-		GroupLocalServiceUtil.updateGroup(group);
+		Group group = GroupTestUtil.addGroup(
+			companyId, userId, GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 		testUpdateCompanyNames(
 			company,
 			new String[] {StringPool.BLANK, group.getDescriptiveName()}, true);
-
-		GroupLocalServiceUtil.deleteGroup(group);
 
 		CompanyLocalServiceUtil.deleteCompany(company.getCompanyId());
 	}

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -65,6 +65,7 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.VirtualHostLocalServiceUtil;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
@@ -122,6 +123,10 @@ import org.springframework.mock.web.MockServletContext;
  * @author Mika Koivisto
  * @author Dale Shan
  */
+@DataGuard(
+	autoDeleteClassNames = "com.liferay.portal.kernel.model.ClassName",
+	scope = DataGuard.Scope.METHOD
+)
 @RunWith(Arquillian.class)
 @SybaseDumpTransactionLog(dumpBefore = {SybaseDump.CLASS, SybaseDump.METHOD})
 public class CompanyLocalServiceTest {

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -773,8 +773,7 @@ public class CompanyLocalServiceTest {
 	public void testGetCompanyByVirtualHost() throws Exception {
 		String virtualHostName = "::1";
 
-		Company company = CompanyLocalServiceUtil.addCompany(
-			null, virtualHostName, virtualHostName, "test.com", false, 0, true);
+		Company company = addCompany(virtualHostName);
 
 		Assert.assertEquals(
 			company,
@@ -788,33 +787,26 @@ public class CompanyLocalServiceTest {
 
 	@Test
 	public void testUpdateCompanyLocales() throws Exception {
-		long companyId = CompanyThreadLocal.getCompanyId();
+		Company company = addCompany();
 
-		try {
-			Company company = addCompany();
+		String languageId = "ca_ES";
+		TimeZone timeZone = company.getTimeZone();
 
-			CompanyThreadLocal.setCompanyId(company.getCompanyId());
+		CompanyLocalServiceUtil.updateDisplay(
+			company.getCompanyId(), languageId, timeZone.getID());
 
-			String languageId = "ca_ES";
-			TimeZone timeZone = company.getTimeZone();
+		UnicodeProperties unicodeProperties = new UnicodeProperties();
 
-			CompanyLocalServiceUtil.updateDisplay(
-				company.getCompanyId(), languageId, timeZone.getID());
+		unicodeProperties.put(PropsKeys.LOCALES, languageId);
 
-			UnicodeProperties unicodeProperties = new UnicodeProperties();
+		CompanyLocalServiceUtil.updatePreferences(
+			company.getCompanyId(), unicodeProperties);
 
-			unicodeProperties.put(PropsKeys.LOCALES, languageId);
+		Assert.assertEquals(
+			Collections.singleton(LocaleUtil.fromLanguageId(languageId)),
+			LanguageUtil.getAvailableLocales());
 
-			CompanyLocalServiceUtil.updatePreferences(
-				company.getCompanyId(), unicodeProperties);
-
-			Assert.assertEquals(
-				Collections.singleton(LocaleUtil.fromLanguageId(languageId)),
-				LanguageUtil.getAvailableLocales());
-		}
-		finally {
-			CompanyThreadLocal.setCompanyId(companyId);
-		}
+		CompanyLocalServiceUtil.deleteCompany(company);
 	}
 
 	@Test
@@ -864,6 +856,8 @@ public class CompanyLocalServiceTest {
 		Assert.assertEquals(
 			languageIds,
 			groupTypeSettingsUnicodeProperties.getProperty(PropsKeys.LOCALES));
+
+		CompanyLocalServiceUtil.deleteCompany(company);
 	}
 
 	@Test
@@ -946,12 +940,16 @@ public class CompanyLocalServiceTest {
 	}
 
 	protected Company addCompany() throws Exception {
-		String webId = RandomTestUtil.randomString() + "test.com";
+		return addCompany(RandomTestUtil.randomString() + "test.com");
+	}
 
+	protected Company addCompany(String webId) throws Exception {
 		Company company = CompanyLocalServiceUtil.addCompany(
 			null, webId, webId, "test.com", false, 0, true);
 
 		PortalInstances.initCompany(_mockServletContext, webId);
+
+		CompanyThreadLocal.setCompanyId(company.getCompanyId());
 
 		return company;
 	}

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryGroupRelLocalServiceTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -121,6 +122,7 @@ public class DepotEntryGroupRelLocalServiceTest {
 		}
 	}
 
+	@DataGuard(autoDeleteClassNames = {}, scope = DataGuard.Scope.METHOD)
 	@Test
 	public void testDeleteGroup() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry();

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -117,6 +118,7 @@ public class DepotEntryLocalServiceTest {
 		_addDepotEntry(null, null);
 	}
 
+	@DataGuard(autoDeleteClassNames = {}, scope = DataGuard.Scope.METHOD)
 	@Test
 	public void testDeleteCompany() throws Exception {
 		Company company = CompanyTestUtil.addCompany();
@@ -141,6 +143,7 @@ public class DepotEntryLocalServiceTest {
 				depotEntry.getDepotEntryId()));
 	}
 
+	@DataGuard(autoDeleteClassNames = {}, scope = DataGuard.Scope.METHOD)
 	@Test(expected = NoSuchGroupException.class)
 	public void testDeleteDepotEntry() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry("name", "description");

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/model/listener/CompanyModelListener.java
@@ -12,12 +12,10 @@
  * details.
  */
 
-package com.liferay.account.internal.model.listener;
+package com.liferay.dispatch.internal.model.listener;
 
-import com.liferay.account.model.AccountGroup;
-import com.liferay.account.service.AccountEntryLocalService;
-import com.liferay.account.service.AccountGroupLocalService;
-import com.liferay.account.service.AccountRoleLocalService;
+import com.liferay.dispatch.model.DispatchTrigger;
+import com.liferay.dispatch.service.DispatchTriggerLocalService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -30,33 +28,26 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Drew Brokke
+ * @author Jorge Díaz
  */
 @Component(immediate = true, service = ModelListener.class)
 public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterRemove(Company company) throws ModelListenerException {
-		_accountRoleLocalService.deleteAccountRolesByCompanyId(
-			company.getCompanyId());
-
 		try {
-			_deleteAccountGroups(company);
+			_deleteDispatchTriggers(company);
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);
 		}
 	}
 
-	@Override
-	public void onBeforeRemove(Company company) throws ModelListenerException {
-		_accountEntryLocalService.deleteAccountEntriesByCompanyId(
-			company.getCompanyId());
-	}
+	private void _deleteDispatchTriggers(Company company)
+		throws PortalException {
 
-	private void _deleteAccountGroups(Company company) throws PortalException {
 		ActionableDynamicQuery actionableDynamicQuery =
-			_accountGroupLocalService.getActionableDynamicQuery();
+			_dispatchTriggerLocalService.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> dynamicQuery.add(
@@ -64,19 +55,14 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 					"companyId", company.getCompanyId())));
 
 		actionableDynamicQuery.setPerformActionMethod(
-			accountGroup -> _accountGroupLocalService.deleteAccountGroup(
-				(AccountGroup)accountGroup));
+			dispatchTrigger ->
+				_dispatchTriggerLocalService.deleteDispatchTrigger(
+					(DispatchTrigger)dispatchTrigger));
 
 		actionableDynamicQuery.performActions();
 	}
 
 	@Reference
-	private AccountEntryLocalService _accountEntryLocalService;
-
-	@Reference
-	private AccountGroupLocalService _accountGroupLocalService;
-
-	@Reference
-	private AccountRoleLocalService _accountRoleLocalService;
+	private DispatchTriggerLocalService _dispatchTriggerLocalService;
 
 }

--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/service/impl/DispatchTriggerLocalServiceImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.scheduler.SchedulerException;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalRunMode;
@@ -94,7 +95,9 @@ public class DispatchTriggerLocalServiceImpl
 			DispatchTrigger dispatchTrigger)
 		throws PortalException {
 
-		if (dispatchTrigger.isSystem() && !PortalRunMode.isTestMode()) {
+		if (dispatchTrigger.isSystem() && !PortalRunMode.isTestMode() &&
+			!CompanyThreadLocal.isDeleteInProcess()) {
+
 			return dispatchTrigger;
 		}
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/CompanyModelListener.java
@@ -12,12 +12,10 @@
  * details.
  */
 
-package com.liferay.account.internal.model.listener;
+package com.liferay.document.library.internal.model.listener;
 
-import com.liferay.account.model.AccountGroup;
-import com.liferay.account.service.AccountEntryLocalService;
-import com.liferay.account.service.AccountGroupLocalService;
-import com.liferay.account.service.AccountRoleLocalService;
+import com.liferay.document.library.model.DLStorageQuota;
+import com.liferay.document.library.service.DLStorageQuotaLocalService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -30,33 +28,26 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Drew Brokke
+ * @author Jorge Díaz
  */
 @Component(immediate = true, service = ModelListener.class)
 public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterRemove(Company company) throws ModelListenerException {
-		_accountRoleLocalService.deleteAccountRolesByCompanyId(
-			company.getCompanyId());
-
 		try {
-			_deleteAccountGroups(company);
+			_deleteDLStorageQuotas(company);
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);
 		}
 	}
 
-	@Override
-	public void onBeforeRemove(Company company) throws ModelListenerException {
-		_accountEntryLocalService.deleteAccountEntriesByCompanyId(
-			company.getCompanyId());
-	}
+	private void _deleteDLStorageQuotas(Company company)
+		throws PortalException {
 
-	private void _deleteAccountGroups(Company company) throws PortalException {
 		ActionableDynamicQuery actionableDynamicQuery =
-			_accountGroupLocalService.getActionableDynamicQuery();
+			_dlStorageQuotaLocalService.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> dynamicQuery.add(
@@ -64,19 +55,13 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 					"companyId", company.getCompanyId())));
 
 		actionableDynamicQuery.setPerformActionMethod(
-			accountGroup -> _accountGroupLocalService.deleteAccountGroup(
-				(AccountGroup)accountGroup));
+			dlStorageQuota -> _dlStorageQuotaLocalService.deleteDLStorageQuota(
+				(DLStorageQuota)dlStorageQuota));
 
 		actionableDynamicQuery.performActions();
 	}
 
 	@Reference
-	private AccountEntryLocalService _accountEntryLocalService;
-
-	@Reference
-	private AccountGroupLocalService _accountGroupLocalService;
-
-	@Reference
-	private AccountRoleLocalService _accountRoleLocalService;
+	private DLStorageQuotaLocalService _dlStorageQuotaLocalService;
 
 }

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLStorageQuotaDLFileVersionModelListener.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/model/listener/DLStorageQuotaDLFileVersionModelListener.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -44,6 +45,10 @@ public class DLStorageQuotaDLFileVersionModelListener
 	@Override
 	public void onAfterRemove(DLFileVersion dlFileVersion)
 		throws ModelListenerException {
+
+		if (CompanyThreadLocal.isDeleteInProcess()) {
+			return;
+		}
 
 		_dlStorageQuotaLocalService.incrementStorageSize(
 			dlFileVersion.getCompanyId(), -dlFileVersion.getSize());

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/service/impl/DLStorageQuotaLocalServiceImpl.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/service/impl/DLStorageQuotaLocalServiceImpl.java
@@ -52,7 +52,16 @@ public class DLStorageQuotaLocalServiceImpl
 	@BufferedIncrement(incrementClass = NumberIncrement.class)
 	@Override
 	public void incrementStorageSize(long companyId, long increment) {
-		DLStorageQuota dlStorageQuota = _getDLStorageQuota(companyId);
+		DLStorageQuota dlStorageQuota =
+			dlStorageQuotaPersistence.fetchByCompanyId(companyId);
+
+		if (dlStorageQuota == null) {
+			if (increment <= 0) {
+				return;
+			}
+
+			dlStorageQuota = _getDLStorageQuota(companyId);
+		}
 
 		dlStorageQuota.setStorageSize(
 			dlStorageQuota.getStorageSize() + increment);

--- a/modules/apps/document-library/document-library-sync-service/src/main/java/com/liferay/document/library/sync/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/document-library/document-library-sync-service/src/main/java/com/liferay/document/library/sync/internal/model/listener/CompanyModelListener.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.document.library.sync.internal.model.listener;
+
+import com.liferay.document.library.sync.model.DLSyncEvent;
+import com.liferay.document.library.sync.service.DLSyncEventLocalService;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jorge Díaz
+ */
+@Component(immediate = true, service = ModelListener.class)
+public class CompanyModelListener extends BaseModelListener<Company> {
+
+	@Override
+	public void onAfterRemove(Company company) throws ModelListenerException {
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				_deleteDLSyncEvent(company);
+
+				return null;
+			});
+	}
+
+	private void _deleteDLSyncEvent(Company company) throws PortalException {
+		ActionableDynamicQuery actionableDynamicQuery =
+			_dlSyncEventLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> dynamicQuery.add(
+				RestrictionsFactoryUtil.eq(
+					"companyId", company.getCompanyId())));
+
+		actionableDynamicQuery.setPerformActionMethod(
+			dlSyncEvent -> _dlSyncEventLocalService.deleteDLSyncEvent(
+				(DLSyncEvent)dlSyncEvent));
+
+		actionableDynamicQuery.performActions();
+	}
+
+	@Reference
+	private DLSyncEventLocalService _dlSyncEventLocalService;
+
+}

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryMetadataLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryMetadataLocalServiceTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -118,6 +119,7 @@ public class DLFileEntryMetadataLocalServiceTest {
 			serviceContext);
 	}
 
+	@DataGuard(autoDeleteClassNames = {}, scope = DataGuard.Scope.METHOD)
 	@Test
 	public void testDeleteGroup() throws Exception {
 		User user = TestPropsValues.getUser();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/web/exportimport/data/handler/test/DLPortletDataHandlerTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/web/exportimport/data/handler/test/DLPortletDataHandlerTest.java
@@ -60,6 +60,7 @@ import com.liferay.portal.kernel.service.RepositoryLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -188,6 +189,7 @@ public class DLPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 		Assert.assertEquals(0, folderModelAdditionCounter.getValue());
 	}
 
+	@DataGuard(autoDeleteClassNames = {}, scope = DataGuard.Scope.METHOD)
 	@Test
 	public void testDeleteAllFolders() throws Exception {
 		Group group = GroupTestUtil.addGroup();
@@ -218,6 +220,7 @@ public class DLPortletDataHandlerTest extends BasePortletDataHandlerTestCase {
 		Assert.assertEquals(0, foldersCount);
 	}
 
+	@DataGuard(autoDeleteClassNames = {}, scope = DataGuard.Scope.METHOD)
 	@Test
 	public void testDeleteGroup() throws Exception {
 		Class<?> clazz = getClass();

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/model/listener/CompanyModelListener.java
@@ -12,12 +12,11 @@
  * details.
  */
 
-package com.liferay.account.internal.model.listener;
+package com.liferay.oauth2.provider.internal.model.listener;
 
-import com.liferay.account.model.AccountGroup;
-import com.liferay.account.service.AccountEntryLocalService;
-import com.liferay.account.service.AccountGroupLocalService;
-import com.liferay.account.service.AccountRoleLocalService;
+import com.liferay.oauth2.provider.model.OAuth2ScopeGrant;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.ModelListenerException;
@@ -30,33 +29,28 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Drew Brokke
+ * @author Jorge Díaz
  */
 @Component(immediate = true, service = ModelListener.class)
 public class CompanyModelListener extends BaseModelListener<Company> {
 
 	@Override
 	public void onAfterRemove(Company company) throws ModelListenerException {
-		_accountRoleLocalService.deleteAccountRolesByCompanyId(
-			company.getCompanyId());
-
 		try {
-			_deleteAccountGroups(company);
+			_oAuth2ApplicationLocalService.deleteOAuth2Applications(
+				company.getCompanyId());
+			_deleteOAuth2ScopeGrant(company);
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);
 		}
 	}
 
-	@Override
-	public void onBeforeRemove(Company company) throws ModelListenerException {
-		_accountEntryLocalService.deleteAccountEntriesByCompanyId(
-			company.getCompanyId());
-	}
+	private void _deleteOAuth2ScopeGrant(Company company)
+		throws PortalException {
 
-	private void _deleteAccountGroups(Company company) throws PortalException {
 		ActionableDynamicQuery actionableDynamicQuery =
-			_accountGroupLocalService.getActionableDynamicQuery();
+			_oAuth2ScopeGrantLocalService.getActionableDynamicQuery();
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> dynamicQuery.add(
@@ -64,19 +58,17 @@ public class CompanyModelListener extends BaseModelListener<Company> {
 					"companyId", company.getCompanyId())));
 
 		actionableDynamicQuery.setPerformActionMethod(
-			accountGroup -> _accountGroupLocalService.deleteAccountGroup(
-				(AccountGroup)accountGroup));
+			oAuth2ScopeGrant ->
+				_oAuth2ScopeGrantLocalService.deleteOAuth2ScopeGrant(
+					(OAuth2ScopeGrant)oAuth2ScopeGrant));
 
 		actionableDynamicQuery.performActions();
 	}
 
 	@Reference
-	private AccountEntryLocalService _accountEntryLocalService;
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	@Reference
-	private AccountGroupLocalService _accountGroupLocalService;
-
-	@Reference
-	private AccountRoleLocalService _accountRoleLocalService;
+	private OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
 
 }

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/model/listener/CompanyModelListener.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/model/listener/CompanyModelListener.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.audit.storage.internal.model.listener;
+
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.security.audit.storage.model.AuditEvent;
+import com.liferay.portal.security.audit.storage.service.AuditEventLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jorge Díaz
+ */
+@Component(immediate = true, service = ModelListener.class)
+public class CompanyModelListener extends BaseModelListener<Company> {
+
+	@Override
+	public void onAfterRemove(Company company) throws ModelListenerException {
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				_deleteAuditEvents(company);
+
+				return null;
+			});
+	}
+
+	private void _deleteAuditEvents(Company company) throws PortalException {
+		ActionableDynamicQuery actionableDynamicQuery =
+			_auditEventLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> dynamicQuery.add(
+				RestrictionsFactoryUtil.eq(
+					"companyId", company.getCompanyId())));
+
+		actionableDynamicQuery.setPerformActionMethod(
+			auditEvent -> _auditEventLocalService.deleteAuditEvent(
+				(AuditEvent)auditEvent));
+
+		actionableDynamicQuery.performActions();
+	}
+
+	@Reference
+	private AuditEventLocalService _auditEventLocalService;
+
+}

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -29,6 +29,7 @@ import com.liferay.petra.io.StreamUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -53,6 +54,14 @@ import org.osgi.framework.FrameworkUtil;
 /**
  * @author Brian Wing Shun Chan
  */
+@DataGuard(
+	autoDeleteClassNames = {
+		"com.liferay.document.library.sync.model.DLSyncEvent",
+		"com.liferay.portal.kernel.model.ClassName",
+		"com.liferay.portal.security.audit.storage.model.AuditEvent"
+	},
+	scope = DataGuard.Scope.CLASS
+)
 @RunWith(Arquillian.class)
 public class BundleSiteInitializerTest {
 

--- a/modules/apps/site/site-insurance-site-initializer-test/src/testIntegration/java/com/liferay/site/insurance/site/initializer/test/internal/test/InsuranceSiteInitializerTest.java
+++ b/modules/apps/site/site-insurance-site-initializer-test/src/testIntegration/java/com/liferay/site/insurance/site/initializer/test/internal/test/InsuranceSiteInitializerTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -71,6 +72,14 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /**
  * @author Jürgen Kappler
  */
+@DataGuard(
+	autoDeleteClassNames = {
+		"com.liferay.document.library.sync.model.DLSyncEvent",
+		"com.liferay.portal.kernel.model.ClassName",
+		"com.liferay.portal.security.audit.storage.model.AuditEvent"
+	},
+	scope = DataGuard.Scope.CLASS
+)
 @RunWith(Arquillian.class)
 public class InsuranceSiteInitializerTest {
 

--- a/modules/apps/site/site-insurance-site-initializer-test/src/testIntegration/java/com/liferay/site/insurance/site/initializer/test/internal/test/InsuranceSiteInitializerTest.java
+++ b/modules/apps/site/site-insurance-site-initializer-test/src/testIntegration/java/com/liferay/site/insurance/site/initializer/test/internal/test/InsuranceSiteInitializerTest.java
@@ -30,10 +30,10 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -155,6 +155,8 @@ public class InsuranceSiteInitializerTest {
 				_group.getGroupId(), "raylife"));
 
 		_groupLocalService.deleteGroup(_group);
+
+		_userLocalService.deleteUser(_user);
 	}
 
 	private String[] _getLayoutNames(long groupId, boolean privateLayout) {
@@ -267,7 +269,9 @@ public class InsuranceSiteInitializerTest {
 	@Inject
 	private StyleBookEntryLocalService _styleBookEntryLocalService;
 
-	@DeleteAfterTestRun
 	private User _user;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/site/site-insurance-site-initializer-test/src/testIntegration/java/com/liferay/site/insurance/site/initializer/test/internal/test/InsuranceSiteInitializerTest.java
+++ b/modules/apps/site/site-insurance-site-initializer-test/src/testIntegration/java/com/liferay/site/insurance/site/initializer/test/internal/test/InsuranceSiteInitializerTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -46,7 +47,6 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.site.exception.InitializationException;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerRegistry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
@@ -110,7 +110,7 @@ public class InsuranceSiteInitializerTest {
 	}
 
 	@Test
-	public void testCreateInsuranceSite() throws InitializationException {
+	public void testCreateInsuranceSite() throws Exception {
 		SiteInitializer siteInitializer =
 			_siteInitializerRegistry.getSiteInitializer(
 				"site-insurance-site-initializer");
@@ -153,6 +153,8 @@ public class InsuranceSiteInitializerTest {
 		Assert.assertNotNull(
 			_styleBookEntryLocalService.fetchStyleBookEntry(
 				_group.getGroupId(), "raylife"));
+
+		_groupLocalService.deleteGroup(_group);
 	}
 
 	private String[] _getLayoutNames(long groupId, boolean privateLayout) {
@@ -245,8 +247,10 @@ public class InsuranceSiteInitializerTest {
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
-	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 	private Layout _layout;
 

--- a/modules/apps/subscription/subscription-test/src/testIntegration/java/com/liferay/subscription/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/subscription/subscription-test/src/testIntegration/java/com/liferay/subscription/internal/model/listener/test/GroupModelListenerTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -44,6 +45,7 @@ public class GroupModelListenerTest {
 		_group = GroupTestUtil.addGroup();
 	}
 
+	@DataGuard(autoDeleteClassNames = {}, scope = DataGuard.Scope.METHOD)
 	@Test
 	public void testDeleteGroupSubscriptions() throws Exception {
 		int count = SubscriptionLocalServiceUtil.getUserSubscriptionsCount(

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -380,9 +380,11 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 					companyId);
 		}
 
+		Long previousCompanyId = CompanyThreadLocal.getCompanyId();
 		boolean deleteInProcess = CompanyThreadLocal.isDeleteInProcess();
 
 		try {
+			CompanyThreadLocal.setCompanyId(companyId);
 			CompanyThreadLocal.setDeleteInProcess(true);
 
 			return doDeleteCompany(companyId);
@@ -395,6 +397,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			throw portalException;
 		}
 		finally {
+			CompanyThreadLocal.setCompanyId(previousCompanyId);
 			CompanyThreadLocal.setDeleteInProcess(deleteInProcess);
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -942,8 +942,6 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 				}
 			}
 
-			systemEventLocalService.deleteSystemEvents(group.getGroupId());
-
 			// Themes
 
 			ThemeLoader themeLoader =
@@ -1015,6 +1013,10 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 				workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
 					workflowDefinitionLink);
 			}
+
+			// System Events
+
+			systemEventLocalService.deleteSystemEvents(group.getGroupId());
 
 			// Group
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuard.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuard.java
@@ -28,6 +28,8 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface DataGuard {
 
+	public boolean autoDelete() default true;
+
 	public Scope scope() default Scope.CLASS;
 
 	public enum Scope {

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuard.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuard.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface DataGuard {
 
-	public boolean autoDelete() default true;
+	public String[] autoDeleteClassNames() default "*";
 
 	public Scope scope() default Scope.CLASS;
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuard.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuard.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
+@Target({ElementType.METHOD, ElementType.TYPE})
 public @interface DataGuard {
 
 	public String[] autoDeleteClassNames() default "*";

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRule.java
@@ -34,7 +34,8 @@ public class DataGuardTestRule
 			return;
 		}
 
-		DataGuardTestRuleUtil.afterClass(dataBag, description.getClassName());
+		DataGuardTestRuleUtil.afterClass(
+			dataBag, description.getClassName(), _autoDelete(description));
 	}
 
 	@Override
@@ -47,7 +48,8 @@ public class DataGuardTestRule
 			return;
 		}
 
-		DataGuardTestRuleUtil.afterMethod(dataBag, description.getClassName());
+		DataGuardTestRuleUtil.afterMethod(
+			dataBag, description.getClassName(), _autoDelete(description));
 	}
 
 	@Override
@@ -83,6 +85,18 @@ public class DataGuardTestRule
 	}
 
 	private DataGuardTestRule() {
+	}
+
+	private boolean _autoDelete(Description description) {
+		Class<?> testClass = description.getTestClass();
+
+		DataGuard dataGuard = testClass.getAnnotation(DataGuard.class);
+
+		if (dataGuard == null) {
+			return true;
+		}
+
+		return dataGuard.autoDelete();
 	}
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRule.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.kernel.test.rule;
 
+import com.liferay.petra.string.StringPool;
+
 import org.junit.runner.Description;
 
 /**
@@ -35,7 +37,8 @@ public class DataGuardTestRule
 		}
 
 		DataGuardTestRuleUtil.afterClass(
-			dataBag, description.getClassName(), _autoDelete(description));
+			dataBag, description.getClassName(),
+			_autoDeleteClassNames(description));
 	}
 
 	@Override
@@ -49,7 +52,8 @@ public class DataGuardTestRule
 		}
 
 		DataGuardTestRuleUtil.afterMethod(
-			dataBag, description.getClassName(), _autoDelete(description));
+			dataBag, description.getClassName(),
+			_autoDeleteClassNames(description));
 	}
 
 	@Override
@@ -87,16 +91,16 @@ public class DataGuardTestRule
 	private DataGuardTestRule() {
 	}
 
-	private boolean _autoDelete(Description description) {
+	private String[] _autoDeleteClassNames(Description description) {
 		Class<?> testClass = description.getTestClass();
 
 		DataGuard dataGuard = testClass.getAnnotation(DataGuard.class);
 
 		if (dataGuard == null) {
-			return true;
+			return new String[] {StringPool.STAR};
 		}
 
-		return dataGuard.autoDelete();
+		return dataGuard.autoDeleteClassNames();
 	}
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRule.java
@@ -75,9 +75,13 @@ public class DataGuardTestRule
 	protected DataGuardTestRuleUtil.DataBag beforeMethod(
 		Description description, Object target) {
 
-		Class<?> testClass = description.getTestClass();
+		DataGuard dataGuard = description.getAnnotation(DataGuard.class);
 
-		DataGuard dataGuard = testClass.getAnnotation(DataGuard.class);
+		if (dataGuard == null) {
+			Class<?> testClass = description.getTestClass();
+
+			dataGuard = testClass.getAnnotation(DataGuard.class);
+		}
 
 		if ((dataGuard == null) ||
 			(dataGuard.scope() != DataGuard.Scope.METHOD)) {
@@ -92,9 +96,15 @@ public class DataGuardTestRule
 	}
 
 	private String[] _autoDeleteClassNames(Description description) {
+		DataGuard dataGuard = description.getAnnotation(DataGuard.class);
+
+		if (dataGuard != null) {
+			return dataGuard.autoDeleteClassNames();
+		}
+
 		Class<?> testClass = description.getTestClass();
 
-		DataGuard dataGuard = testClass.getAnnotation(DataGuard.class);
+		dataGuard = testClass.getAnnotation(DataGuard.class);
 
 		if (dataGuard == null) {
 			return new String[] {StringPool.STAR};

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -620,6 +620,20 @@ public class DataGuardTestRuleUtil {
 	private static class RecordingSessionWrapper extends SessionWrapper {
 
 		@Override
+		public void delete(Object object) throws ORMException {
+			super.delete(object);
+
+			BaseModel<?> baseModel = (BaseModel<?>)object;
+
+			Map<Serializable, String> map = _records.get(
+				baseModel.getModelClassName());
+
+			if (map != null) {
+				map.remove(baseModel.getPrimaryKeyObj());
+			}
+		}
+
+		@Override
 		public Serializable save(Object object) throws ORMException {
 			_record(object);
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -103,9 +103,7 @@ public class DataGuardTestRuleUtil {
 			DataBag dataBag, String testClassName, boolean autoDelete)
 		throws Throwable {
 
-		_autoDeleteAndAssert(
-			testClassName, dataBag._dataMap, dataBag._portlets,
-			dataBag._records, autoDelete);
+		afterClass(dataBag, testClassName, autoDelete);
 	}
 
 	public static DataBag beforeClass() {
@@ -127,9 +125,7 @@ public class DataGuardTestRuleUtil {
 	}
 
 	public static DataBag beforeMethod() {
-		return new DataBag(
-			_captureDataMap(), PortletLocalServiceUtil.getPortlets(), null,
-			null);
+		return beforeClass();
 	}
 
 	public static class DataBag {

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.registry.Registry;
@@ -74,11 +75,12 @@ public class DataGuardTestRuleUtil {
 	public static void afterClass(DataBag dataBag, String testClassName)
 		throws Throwable {
 
-		afterClass(dataBag, testClassName, true);
+		afterClass(dataBag, testClassName, new String[] {StringPool.STAR});
 	}
 
 	public static void afterClass(
-			DataBag dataBag, String testClassName, boolean autoDelete)
+			DataBag dataBag, String testClassName,
+			String[] autoDeleteClassNames)
 		throws Throwable {
 
 		ServiceRegistration<SessionCustomizer> serviceRegistration =
@@ -90,20 +92,21 @@ public class DataGuardTestRuleUtil {
 
 		_autoDeleteAndAssert(
 			testClassName, dataBag._dataMap, dataBag._portlets,
-			dataBag._records, autoDelete);
+			dataBag._records, autoDeleteClassNames);
 	}
 
 	public static void afterMethod(DataBag dataBag, String testClassName)
 		throws Throwable {
 
-		afterMethod(dataBag, testClassName, true);
+		afterMethod(dataBag, testClassName, new String[] {StringPool.STAR});
 	}
 
 	public static void afterMethod(
-			DataBag dataBag, String testClassName, boolean autoDelete)
+			DataBag dataBag, String testClassName,
+			String[] autoDeleteClassNames)
 		throws Throwable {
 
-		afterClass(dataBag, testClassName, autoDelete);
+		afterClass(dataBag, testClassName, autoDeleteClassNames);
 	}
 
 	public static DataBag beforeClass() {
@@ -153,7 +156,8 @@ public class DataGuardTestRuleUtil {
 			String testClassName,
 			Map<String, List<BaseModel<?>>> previousDataMap,
 			List<Portlet> previousPortlets,
-			Map<String, Map<Serializable, String>> records, boolean autoDelete)
+			Map<String, Map<Serializable, String>> records,
+			String[] autoDeleteClassNames)
 		throws Throwable {
 
 		for (Portlet portlet : PortletLocalServiceUtil.getPortlets()) {
@@ -162,9 +166,7 @@ public class DataGuardTestRuleUtil {
 			}
 		}
 
-		if (autoDelete) {
-			_autoDeleteLeftovers(previousDataMap);
-		}
+		_autoDeleteLeftovers(previousDataMap, autoDeleteClassNames);
 
 		StringBundler sb = new StringBundler();
 
@@ -224,8 +226,12 @@ public class DataGuardTestRuleUtil {
 	}
 
 	private static void _autoDeleteLeftovers(
-			Map<String, List<BaseModel<?>>> previousDataMap)
+			Map<String, List<BaseModel<?>>> previousDataMap,
+			String[] autoDeleteClassNames)
 		throws Throwable {
+
+		boolean autoDeleteAll = ArrayUtil.contains(
+			autoDeleteClassNames, StringPool.STAR);
 
 		Map<String, PersistedModelLocalService> persistedModelLocalServices =
 			_getPersistedModelLocalServices();
@@ -239,6 +245,12 @@ public class DataGuardTestRuleUtil {
 					dataMap.entrySet()) {
 
 				String className = entry.getKey();
+
+				if (!autoDeleteAll &&
+					!ArrayUtil.contains(autoDeleteClassNames, className)) {
+
+					continue;
+				}
 
 				PersistedModelLocalService persistedModelLocalService =
 					persistedModelLocalServices.get(className);

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -74,6 +74,13 @@ public class DataGuardTestRuleUtil {
 	public static void afterClass(DataBag dataBag, String testClassName)
 		throws Throwable {
 
+		afterClass(dataBag, testClassName, true);
+	}
+
+	public static void afterClass(
+			DataBag dataBag, String testClassName, boolean autoDelete)
+		throws Throwable {
+
 		ServiceRegistration<SessionCustomizer> serviceRegistration =
 			dataBag._serviceRegistration;
 
@@ -83,15 +90,22 @@ public class DataGuardTestRuleUtil {
 
 		_autoDeleteAndAssert(
 			testClassName, dataBag._dataMap, dataBag._portlets,
-			dataBag._records);
+			dataBag._records, autoDelete);
 	}
 
 	public static void afterMethod(DataBag dataBag, String testClassName)
 		throws Throwable {
 
+		afterMethod(dataBag, testClassName, true);
+	}
+
+	public static void afterMethod(
+			DataBag dataBag, String testClassName, boolean autoDelete)
+		throws Throwable {
+
 		_autoDeleteAndAssert(
 			testClassName, dataBag._dataMap, dataBag._portlets,
-			dataBag._records);
+			dataBag._records, autoDelete);
 	}
 
 	public static DataBag beforeClass() {
@@ -143,7 +157,7 @@ public class DataGuardTestRuleUtil {
 			String testClassName,
 			Map<String, List<BaseModel<?>>> previousDataMap,
 			List<Portlet> previousPortlets,
-			Map<String, Map<Serializable, String>> records)
+			Map<String, Map<Serializable, String>> records, boolean autoDelete)
 		throws Throwable {
 
 		for (Portlet portlet : PortletLocalServiceUtil.getPortlets()) {
@@ -152,7 +166,9 @@ public class DataGuardTestRuleUtil {
 			}
 		}
 
-		_autoDeleteLeftovers(previousDataMap);
+		if (autoDelete) {
+			_autoDeleteLeftovers(previousDataMap);
+		}
 
 		StringBundler sb = new StringBundler();
 


### PR DESCRIPTION
- LPS-138761 DataGuard: Make configurable the autoDelete functionality
- LPS-138761 DataGuard: Store stackthreads also with method scope
- LPS-138761 DataGuard: Change the autoDelete flag to a className list to autoDelete this allow us to configure specific entities to be delete. Its default value is * that means it has to delete all of them
- LPS-138761 DataGuard: Remove the deleted objects from the _records map as we are not going to need it and we will save memory
- LPS-138761 CompanyLocalServiceTest: Set DataGuard with autoDeleteClassNames = "com.liferay.portal.kernel.model.ClassName" and method = scope to check we are correctly deleting all the created objects of the deleted company
- LPS-138761 CompanyLocalServiceTest: Create the group using the correct company and user
- LPS-138761 CompanyLocalServiceTest: Set the company thread local when creating a new company, it is not necessary to restore the old one because it is already handled in the setUp and tearDown methods
- LPS-138761 Set the companyId to be deleted in the company thread local during deletion to avoid problems with the audit and dl sync events that are created using the companyId from the thread local
- LPS-138761 When creating a new instance, we have the omniadmin user from default company, in the CompanyLocalServiceTest the companyId threadlocal points to the new company so we create a wrong portalpreferences registry
- LPS-138761 Delete the audit events when deleting a company. This must be done in a commit callback because other objects deletions will create new audit events
- LPS-138761 Delete the DL sync events when deleting a company. This must be done in a commit callback because other DLFileEntries and DLFolder deletions will create new DL sync events
- LPS-138761 Delete AccountGroup, DispatchTrigger, DLStorageQuota, OAuth2Application and OAuth2ScopeGrant deleted company records using model listeners
- LPS-138761 Delete the system dispacher trigger when we are deleting the company
- LPS-138761 Don't create new DLStorageQuota records when we are deleting the company, also avoid regenerating the DLStorageQuota object with a negative value
- LPS-138761 Move the SystemEvent deletion to the end because other delete operations can generate new SystemEvent entries
- LPS-0 Add DataGuard with the autoDeleteClassNames configuration
- LPS-0 Correctly delete the group
- LPS-0 Correctly delete the user
