### PR TITLE
HC-51443

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
@@ -50,6 +50,7 @@ import com.liferay.portal.odata.filter.InvalidFilterException;
 import com.liferay.segments.odata.search.ODataSearchAdapter;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -165,9 +166,7 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 			}
 
 			if ((start < indexSearchLimit) && (end >= start)) {
-				for (Document document : docs) {
-					documentList.add(document);
-				}
+				Collections.addAll(documentList, docs);
 
 				if (docs.length != indexSearchLimit) {
 					break;

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
@@ -137,7 +137,7 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 
 		List<Document> documentList = new ArrayList<>();
 
-		Sort sort = new Sort(Field.ENTRY_CLASS_PK, false);
+		Sort sort = new Sort(Field.ENTRY_CLASS_PK, Sort.LONG_TYPE, false);
 
 		while (true) {
 			searchContext.setSorts(sort);

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
@@ -71,7 +71,7 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 		throws PortalException {
 
 		try {
-			SearchContext searchContext = _createSearchContext(companyId, 0, 0);
+			SearchContext searchContext = _createSearchContext(companyId);
 
 			BooleanQuery booleanQuery = _getBooleanQuery(
 				filterString, entityModel, filterParser, locale);
@@ -93,14 +93,15 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 		throws PortalException {
 
 		try {
-			SearchContext searchContext = _createSearchContext(companyId, 0, 0);
+			SearchContext searchContext = _createSearchContext(companyId);
 
 			Indexer<?> indexer = _indexerRegistry.getIndexer(className);
 
 			searchContext.setBooleanClauses(
 				new BooleanClause[] {
 					_getBooleanClause(
-						filterString, entityModel, filterParser, locale)
+						_getBooleanQuery(
+							filterString, entityModel, filterParser, locale))
 				});
 
 			return (int)indexer.searchCount(searchContext);
@@ -151,10 +152,7 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 				booleanQuery, lastDocument);
 
 			searchContext.setBooleanClauses(
-				new BooleanClause[] {
-					BooleanClauseFactoryUtil.create(
-						filteredQuery, BooleanClauseOccur.MUST.getName())
-				});
+				new BooleanClause[] {_getBooleanClause(filteredQuery)});
 
 			Hits hits = indexer.search(searchContext);
 
@@ -189,15 +187,11 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 		return hits;
 	}
 
-	private SearchContext _createSearchContext(
-		long companyId, int start, int end) {
-
+	private SearchContext _createSearchContext(long companyId) {
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setCompanyId(companyId);
-		searchContext.setEnd(end);
 		searchContext.setGroupIds(new long[] {-1L});
-		searchContext.setStart(start);
 
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
@@ -214,14 +208,11 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 		return searchContext;
 	}
 
-	private BooleanClause<Query> _getBooleanClause(
-			String filterString, EntityModel entityModel,
-			FilterParser filterParser, Locale locale)
+	private BooleanClause<Query> _getBooleanClause(BooleanQuery booleanQuery)
 		throws Exception {
 
 		return BooleanClauseFactoryUtil.create(
-			_getBooleanQuery(filterString, entityModel, filterParser, locale),
-			BooleanClauseOccur.MUST.getName());
+			booleanQuery, BooleanClauseOccur.MUST.getName());
 	}
 
 	private BooleanQuery _getBooleanQuery(

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
@@ -147,11 +147,12 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 				searchContext.setStart(indexSearchLimit - 1);
 			}
 
-			BooleanQuery filteredQuery = _getFilteredQuery(
-				booleanQuery, lastDocument);
-
 			searchContext.setBooleanClauses(
-				new BooleanClause[] {_getBooleanClause(filteredQuery)});
+				new BooleanClause[] {
+					_getBooleanClause(
+						_getBooleanQueryFromLastDocument(
+							booleanQuery, lastDocument))
+				});
 
 			Hits hits = indexer.search(searchContext);
 
@@ -237,7 +238,7 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 		return booleanQuery;
 	}
 
-	private BooleanQuery _getFilteredQuery(
+	private BooleanQuery _getBooleanQueryFromLastDocument(
 			BooleanQuery booleanQuery, Document lastDocument)
 		throws ParseException {
 
@@ -245,17 +246,18 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 			return booleanQuery;
 		}
 
-		BooleanQuery filteredQuery = new BooleanQueryImpl();
+		BooleanQuery booleanQueryFromLastDocument = new BooleanQueryImpl();
 
-		filteredQuery.add(booleanQuery, BooleanClauseOccur.MUST);
+		booleanQueryFromLastDocument.add(booleanQuery, BooleanClauseOccur.MUST);
 
 		TermRangeQuery termRangeQuery = new TermRangeQueryImpl(
 			Field.ENTRY_CLASS_PK, lastDocument.get(Field.ENTRY_CLASS_PK), null,
 			false, true);
 
-		filteredQuery.add(termRangeQuery, BooleanClauseOccur.MUST);
+		booleanQueryFromLastDocument.add(
+			termRangeQuery, BooleanClauseOccur.MUST);
 
-		return filteredQuery;
+		return booleanQueryFromLastDocument;
 	}
 
 	private com.liferay.portal.kernel.search.filter.Filter _getSearchFilter(

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
@@ -14,23 +14,35 @@
 
 package com.liferay.segments.internal.odata.search;
 
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.search.BooleanClause;
 import com.liferay.portal.kernel.search.BooleanClauseFactoryUtil;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.HitsImpl;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.search.ParseException;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.SearchResultPermissionFilterFactory;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.TermRangeQuery;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.search.generic.MatchAllQuery;
+import com.liferay.portal.kernel.search.generic.TermRangeQueryImpl;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.Filter;
@@ -38,6 +50,8 @@ import com.liferay.portal.odata.filter.FilterParser;
 import com.liferay.portal.odata.filter.InvalidFilterException;
 import com.liferay.segments.odata.search.ODataSearchAdapter;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
@@ -57,18 +71,14 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 		throws PortalException {
 
 		try {
-			SearchContext searchContext = _createSearchContext(
-				companyId, start, end);
+			SearchContext searchContext = _createSearchContext(companyId, 0, 0);
 
-			Indexer<?> indexer = _indexerRegistry.getIndexer(className);
+			BooleanQuery booleanQuery = _getBooleanQuery(
+				filterString, entityModel, filterParser, locale);
 
-			searchContext.setBooleanClauses(
-				new BooleanClause[] {
-					_getBooleanClause(
-						filterString, entityModel, filterParser, locale)
-				});
-
-			return indexer.search(searchContext);
+			return search(
+				_indexerRegistry.getIndexer(className), searchContext,
+				booleanQuery, start, end);
 		}
 		catch (Exception exception) {
 			throw new PortalException(
@@ -99,6 +109,84 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 			throw new PortalException(
 				"Unable to search with filter " + filterString, exception);
 		}
+	}
+
+	protected Hits search(
+			Indexer<?> indexer, SearchContext searchContext,
+			BooleanQuery booleanQuery, int start, int end)
+		throws ParseException, SearchException {
+
+		if (start == QueryUtil.ALL_POS) {
+			start = 0;
+		}
+		else if (start < 0) {
+			throw new IllegalArgumentException("Invalid start " + start);
+		}
+
+		if (end == QueryUtil.ALL_POS) {
+			end = Integer.MAX_VALUE;
+		}
+		else if (end < start) {
+			throw new IllegalArgumentException("Invalid end " + end);
+		}
+
+		int indexSearchLimit = GetterUtil.getInteger(
+			_props.get(PropsKeys.INDEX_SEARCH_LIMIT));
+
+		Document lastDocument = null;
+
+		List<Document> documentList = new ArrayList<>();
+
+		while (true) {
+			searchContext.setSorts(new Sort(Field.ENTRY_CLASS_PK, false));
+
+			searchContext.setEnd(Math.min(end, indexSearchLimit));
+			searchContext.setStart(Math.min(start, indexSearchLimit));
+
+			if ((start >= indexSearchLimit) && (end >= indexSearchLimit)) {
+				searchContext.setStart(indexSearchLimit - 1);
+			}
+
+			BooleanQuery filteredQuery = _getFilteredQuery(
+				booleanQuery, lastDocument);
+
+			searchContext.setBooleanClauses(
+				new BooleanClause[] {
+					BooleanClauseFactoryUtil.create(
+						filteredQuery, BooleanClauseOccur.MUST.getName())
+				});
+
+			Hits hits = indexer.search(searchContext);
+
+			Document[] docs = hits.getDocs();
+
+			if (docs.length == 0) {
+				break;
+			}
+
+			if ((start < indexSearchLimit) && (end >= start)) {
+				for (Document document : docs) {
+					documentList.add(document);
+				}
+
+				if (docs.length != indexSearchLimit) {
+					break;
+				}
+			}
+
+			lastDocument = docs[docs.length - 1];
+
+			start = Math.max(0, start - indexSearchLimit);
+			end = Math.max(0, end - indexSearchLimit);
+		}
+
+		Hits hits = new HitsImpl();
+
+		hits.setDocs(documentList.toArray(new Document[0]));
+		hits.setLength(documentList.size());
+		hits.setStart(0);
+
+		return hits;
 	}
 
 	private SearchContext _createSearchContext(
@@ -159,6 +247,27 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 		return booleanQuery;
 	}
 
+	private BooleanQuery _getFilteredQuery(
+			BooleanQuery booleanQuery, Document lastDocument)
+		throws ParseException {
+
+		if (lastDocument == null) {
+			return booleanQuery;
+		}
+
+		BooleanQuery filteredQuery = new BooleanQueryImpl();
+
+		filteredQuery.add(booleanQuery, BooleanClauseOccur.MUST);
+
+		TermRangeQuery termRangeQuery = new TermRangeQueryImpl(
+			Field.ENTRY_CLASS_PK, lastDocument.get(Field.ENTRY_CLASS_PK), null,
+			false, true);
+
+		filteredQuery.add(termRangeQuery, BooleanClauseOccur.MUST);
+
+		return filteredQuery;
+	}
+
 	private com.liferay.portal.kernel.search.filter.Filter _getSearchFilter(
 			String filterString, EntityModel entityModel,
 			FilterParser filterParser, Locale locale)
@@ -188,6 +297,9 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 
 	@Reference
 	private IndexerRegistry _indexerRegistry;
+
+	@Reference
+	private Props _props;
 
 	@Reference
 	private SearchResultPermissionFilterFactory

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.search.ParseException;
 import com.liferay.portal.kernel.search.Query;
 import com.liferay.portal.kernel.search.QueryConfig;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.SearchResultPermissionFilterFactory;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.TermRangeQuery;
@@ -115,7 +114,7 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 	protected Hits search(
 			Indexer<?> indexer, SearchContext searchContext,
 			BooleanQuery booleanQuery, int start, int end)
-		throws ParseException, SearchException {
+		throws PortalException {
 
 		if (start == QueryUtil.ALL_POS) {
 			start = 0;
@@ -209,7 +208,7 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 	}
 
 	private BooleanClause<Query> _getBooleanClause(BooleanQuery booleanQuery)
-		throws Exception {
+		throws PortalException {
 
 		return BooleanClauseFactoryUtil.create(
 			booleanQuery, BooleanClauseOccur.MUST.getName());

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/search/ODataSearchAdapterImpl.java
@@ -137,8 +137,10 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 
 		List<Document> documentList = new ArrayList<>();
 
+		Sort sort = new Sort(Field.ENTRY_CLASS_PK, false);
+
 		while (true) {
-			searchContext.setSorts(new Sort(Field.ENTRY_CLASS_PK, false));
+			searchContext.setSorts(sort);
 
 			searchContext.setEnd(Math.min(end, indexSearchLimit));
 			searchContext.setStart(Math.min(start, indexSearchLimit));
@@ -151,7 +153,7 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 				new BooleanClause[] {
 					_getBooleanClause(
 						_getBooleanQueryFromLastDocument(
-							booleanQuery, lastDocument))
+							booleanQuery, sort.getFieldName(), lastDocument))
 				});
 
 			Hits hits = indexer.search(searchContext);
@@ -239,7 +241,7 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 	}
 
 	private BooleanQuery _getBooleanQueryFromLastDocument(
-			BooleanQuery booleanQuery, Document lastDocument)
+			BooleanQuery booleanQuery, String sortField, Document lastDocument)
 		throws ParseException {
 
 		if (lastDocument == null) {
@@ -251,8 +253,7 @@ public class ODataSearchAdapterImpl implements ODataSearchAdapter {
 		booleanQueryFromLastDocument.add(booleanQuery, BooleanClauseOccur.MUST);
 
 		TermRangeQuery termRangeQuery = new TermRangeQueryImpl(
-			Field.ENTRY_CLASS_PK, lastDocument.get(Field.ENTRY_CLASS_PK), null,
-			false, true);
+			sortField, lastDocument.get(sortField), null, false, true);
 
 		booleanQueryFromLastDocument.add(
 			termRangeQuery, BooleanClauseOccur.MUST);


### PR DESCRIPTION
- LPS-1 Initial version of the solution
- LPS-1 Simplify
- LPS-1 Fix compilation issues
- LPS-1 Change method name to _getBooleanQueryFromLastDocument
- LPS-1 Define the Sort object once and then use sort.getFieldName() to get the field name instead of repeating it
- LPS-1 Set type to long
- LPS-1 Use Collections.addAll
