### PR TITLE
LPS-139947_4_fail_test

### DIFF
--- a/modules/apps/segments/segments-test/build.gradle
+++ b/modules/apps/segments/segments-test/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")
 	testIntegrationCompile project(":apps:segments:segments-api")
+	testIntegrationCompile project(":apps:segments:segments-service")
 	testIntegrationCompile project(":apps:segments:segments-test-util")
 	testIntegrationCompile project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationCompile project(":core:osgi-service-tracker-collections")

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
@@ -20,6 +20,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.Group;
@@ -61,10 +62,12 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -74,6 +77,8 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class UserODataRetrieverTest {
+
+	public static final int MORE_THAN_10K = 10002;
 
 	@ClassRule
 	@Rule
@@ -1107,11 +1112,39 @@ public class UserODataRetrieverTest {
 		Assert.assertEquals(_user1, users.get(0));
 	}
 
+	@Ignore
+	@Test
+	public void testRetrieveMoreThan10KUsers() throws Exception {
+		_createmoreThan10kUsers();
+
+		String filterString = String.format("(firstName eq '%s')", "firstName");
+
+		List<User> results = _oDataRetriever.getResults(
+			_group1.getCompanyId(), filterString, LocaleUtil.getDefault(),
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		Assert.assertTrue(MORE_THAN_10K == results.size());
+	}
+
 	private Team _addTeam() throws Exception {
 		return _teamLocalService.addTeam(
 			TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _createmoreThan10kUsers() throws Exception {
+		_group1 = GroupTestUtil.addGroup();
+
+		long groupId = _group1.getGroupId();
+
+		Locale localeDefault = LocaleUtil.getDefault();
+
+		for (int i = 0; i < MORE_THAN_10K; i++) {
+			UserTestUtil.addUser(
+				RandomTestUtil.randomString(), localeDefault, "firstName",
+				RandomTestUtil.randomString(), new long[] {groupId});
+		}
 	}
 
 	private String _toISOFormat(Instant instant) {

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
@@ -1115,7 +1115,17 @@ public class UserODataRetrieverTest {
 	@Ignore
 	@Test
 	public void testRetrieveMoreThan10KUsers() throws Exception {
-		_createmoreThan10kUsers();
+		_group1 = GroupTestUtil.addGroup();
+
+		long groupId = _group1.getGroupId();
+
+		Locale localeDefault = LocaleUtil.getDefault();
+
+		for (int i = 0; i < MORE_THAN_10K; i++) {
+			UserTestUtil.addUser(
+				RandomTestUtil.randomString(), localeDefault, "firstName",
+				RandomTestUtil.randomString(), new long[] {groupId});
+		}
 
 		String filterString = String.format("(firstName eq '%s')", "firstName");
 
@@ -1131,20 +1141,6 @@ public class UserODataRetrieverTest {
 			TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext());
-	}
-
-	private void _createmoreThan10kUsers() throws Exception {
-		_group1 = GroupTestUtil.addGroup();
-
-		long groupId = _group1.getGroupId();
-
-		Locale localeDefault = LocaleUtil.getDefault();
-
-		for (int i = 0; i < MORE_THAN_10K; i++) {
-			UserTestUtil.addUser(
-				RandomTestUtil.randomString(), localeDefault, "firstName",
-				RandomTestUtil.randomString(), new long[] {groupId});
-		}
 	}
 
 	private String _toISOFormat(Instant instant) {

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.util.ISO8601Utils;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
@@ -46,6 +47,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -53,6 +55,7 @@ import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -114,10 +117,17 @@ public class UserODataRetrieverTest {
 			_companyGuestGroup = _groupLocalService.getGroup(
 				_company.getCompanyId(), GroupConstants.GUEST);
 		}
+
+		_safeCloseable = PropsValuesTestUtil.swapWithSafeCloseable(
+			"INDEX_SEARCH_LIMIT", _ELASTICSEARCH_MAX_RESULT_WINDOW);
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
+		if (_safeCloseable != null) {
+			_safeCloseable.close();
+		}
+
 		_companyLocalService.deleteCompany(_company);
 	}
 
@@ -1167,6 +1177,8 @@ public class UserODataRetrieverTest {
 
 	@Inject
 	private static GroupLocalService _groupLocalService;
+
+	private static SafeCloseable _safeCloseable;
 
 	@DeleteAfterTestRun
 	private final List<AssetTag> _assetTags = new ArrayList<>();

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
@@ -1119,11 +1119,11 @@ public class UserODataRetrieverTest {
 
 		String filterString = String.format("(firstName eq '%s')", "firstName");
 
-		List<User> results = _oDataRetriever.getResults(
+		List<User> users = _oDataRetriever.getResults(
 			_group1.getCompanyId(), filterString, LocaleUtil.getDefault(),
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
-		Assert.assertTrue(MORE_THAN_10K == results.size());
+		Assert.assertTrue(MORE_THAN_10K == users.size());
 	}
 
 	private Team _addTeam() throws Exception {

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
@@ -1068,17 +1068,15 @@ public class UserODataRetrieverTest {
 	public void testRetrieveMoreUsersThanElasticsearchMaxResultWindow()
 		throws Exception {
 
-		_group1 = GroupTestUtil.addGroup();
-
-		long groupId = _group1.getGroupId();
+		String firstName = RandomTestUtil.randomString();
 
 		for (int i = 0; i < _MORE_USERS_THAN_ELASTICSEARCH_MAX_RESULT_WINDOW;
 			 i++) {
 
-			_addUser("firstName", new long[] {groupId});
+			_addUser(firstName, _group1);
 		}
 
-		String filterString = String.format("(firstName eq '%s')", "firstName");
+		String filterString = String.format("(firstName eq '%s')", firstName);
 
 		List<User> users = _oDataRetriever.getResults(
 			_group1.getCompanyId(), filterString, LocaleUtil.getDefault(),

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
@@ -79,7 +79,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -92,8 +91,6 @@ import org.osgi.service.cm.ConfigurationAdmin;
  */
 @RunWith(Arquillian.class)
 public class UserODataRetrieverTest {
-
-	public static final int MORE_THAN_10K = 10002;
 
 	@ClassRule
 	@Rule
@@ -1067,14 +1064,17 @@ public class UserODataRetrieverTest {
 		Assert.assertEquals(_user1, users.get(0));
 	}
 
-	@Ignore
 	@Test
-	public void testRetrieveMoreThan10KUsers() throws Exception {
+	public void testRetrieveMoreUsersThanElasticsearchMaxResultWindow()
+		throws Exception {
+
 		_group1 = GroupTestUtil.addGroup();
 
 		long groupId = _group1.getGroupId();
 
-		for (int i = 0; i < MORE_THAN_10K; i++) {
+		for (int i = 0; i < _MORE_USERS_THAN_ELASTICSEARCH_MAX_RESULT_WINDOW;
+			 i++) {
+
 			_addUser("firstName", new long[] {groupId});
 		}
 
@@ -1084,7 +1084,9 @@ public class UserODataRetrieverTest {
 			_group1.getCompanyId(), filterString, LocaleUtil.getDefault(),
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
-		Assert.assertTrue(MORE_THAN_10K == users.size());
+		Assert.assertEquals(
+			users.toString(), _MORE_USERS_THAN_ELASTICSEARCH_MAX_RESULT_WINDOW,
+			users.size());
 	}
 
 	protected static Dictionary<String, Object> setUpElasticsearchProperties()
@@ -1163,6 +1165,9 @@ public class UserODataRetrieverTest {
 			"ElasticsearchConfiguration";
 
 	private static final int _ELASTICSEARCH_MAX_RESULT_WINDOW = 10;
+
+	private static final int _MORE_USERS_THAN_ELASTICSEARCH_MAX_RESULT_WINDOW =
+		_ELASTICSEARCH_MAX_RESULT_WINDOW * 3;
 
 	private static Company _company;
 	private static Group _companyGuestGroup;

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
@@ -55,7 +55,6 @@ import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/UserODataRetrieverTest.java
@@ -89,20 +89,16 @@ public class UserODataRetrieverTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_group1 = GroupTestUtil.addGroup();
-		_group2 = GroupTestUtil.addGroup();
+		_group1 = _addGroup();
+		_group2 = _addGroup();
 	}
 
 	@Test
 	public void testGetUsersFilterByAncestorOrganizationIds() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Organization parentOrganization =
 			OrganizationTestUtil.addOrganization();
@@ -138,12 +134,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByAssetTagIds() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Company company = _companyLocalService.getCompany(
 			_user1.getCompanyId());
@@ -176,12 +168,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByBirthDateEquals() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Date birthDate = _user1.getBirthday();
 
@@ -210,12 +198,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByBirthDateGreater() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Date birthDate = _user1.getBirthday();
 
@@ -246,12 +230,8 @@ public class UserODataRetrieverTest {
 
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Date birthDate = _user1.getBirthday();
 
@@ -274,12 +254,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByBirthDateLower() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Date birthDate = _user1.getBirthday();
 
@@ -308,12 +284,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByBirthDateLowerOrEquals() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Date birthDate = _user1.getBirthday();
 
@@ -336,9 +308,7 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByCompanyId() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
 
 		String filterString = String.format(
 			"(firstName eq '%s') and (companyId eq '%s')", firstName,
@@ -360,12 +330,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByDateModifiedEquals() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Date modifiedDate = _user1.getModifiedDate();
 
@@ -395,12 +361,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByDateModifiedGreater() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Date modifiedDate = _user1.getModifiedDate();
 
@@ -432,12 +394,8 @@ public class UserODataRetrieverTest {
 
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Date modifiedDate = _user1.getModifiedDate();
 
@@ -467,12 +425,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByDateModifiedLower() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Date modifiedDate = _user1.getModifiedDate();
 
@@ -504,12 +458,8 @@ public class UserODataRetrieverTest {
 
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Date modifiedDate = _user1.getModifiedDate();
 
@@ -537,7 +487,7 @@ public class UserODataRetrieverTest {
 
 	@Test
 	public void testGetUsersFilterByEmailAddress() throws Exception {
-		_user1 = UserTestUtil.addUser(_group1.getGroupId());
+		_user1 = _addUser(_group1);
 
 		String filterString =
 			"(emailAddress eq '" + _user1.getEmailAddress() + "')";
@@ -556,7 +506,7 @@ public class UserODataRetrieverTest {
 
 	@Test
 	public void testGetUsersFilterByFirstName() throws Exception {
-		_user1 = UserTestUtil.addUser(_group1.getGroupId());
+		_user1 = _addUser(_group1);
 
 		String filterString = "(firstName eq '" + _user1.getFirstName() + "')";
 
@@ -574,7 +524,7 @@ public class UserODataRetrieverTest {
 
 	@Test
 	public void testGetUsersFilterByFirstNameAndLastName() throws Exception {
-		_user1 = UserTestUtil.addUser(_group1.getGroupId());
+		_user1 = _addUser(_group1);
 
 		String filterString = StringBundler.concat(
 			"(firstName eq '", _user1.getFirstName(), "') and (lastName eq ",
@@ -596,12 +546,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByFirstNameAndNotTeamIds() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		_team = _addTeam();
 
@@ -625,8 +571,8 @@ public class UserODataRetrieverTest {
 
 	@Test
 	public void testGetUsersFilterByFirstNameOrLastName() throws Exception {
-		_user1 = UserTestUtil.addUser(_group1.getGroupId());
-		_user2 = UserTestUtil.addUser(_group1.getGroupId());
+		_user1 = _addUser(_group1);
+		_user2 = _addUser(_group1);
 
 		String filterString = StringBundler.concat(
 			"(firstName eq '", _user1.getFirstName(), "') or (lastName eq '",
@@ -649,7 +595,7 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByFirstNameOrLastNameWithSameFirstName()
 		throws Exception {
 
-		_user1 = UserTestUtil.addUser(_group1.getGroupId());
+		_user1 = _addUser(_group1);
 
 		String filterString = StringBundler.concat(
 			"(firstName eq '", _user1.getFirstName(), "') or (lastName eq ",
@@ -671,7 +617,7 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByFirstNameOrLastNameWithSameFirstNameAndLastName()
 		throws Exception {
 
-		_user1 = UserTestUtil.addUser(_group1.getGroupId());
+		_user1 = _addUser(_group1);
 
 		String filterString = StringBundler.concat(
 			"(firstName eq '", _user1.getFirstName(), "') or (lastName eq '",
@@ -693,13 +639,9 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByGroupId() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(),
-			new long[] {_group1.getGroupId(), _group2.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(
+			firstName, new long[] {_group1.getGroupId(), _group2.getGroupId()});
+		_user2 = _addUser(firstName, _group1);
 
 		String filterString = StringBundler.concat(
 			"(firstName eq '", firstName, "') and (groupId eq '",
@@ -721,13 +663,9 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByGroupIds() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(),
-			new long[] {_group1.getGroupId(), _group2.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(
+			firstName, new long[] {_group1.getGroupId(), _group2.getGroupId()});
+		_user2 = _addUser(firstName, _group1);
 
 		String filterString = StringBundler.concat(
 			"(firstName eq '", firstName, "') and (groupIds eq '",
@@ -749,13 +687,9 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByGroupIdsWithOr() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(),
-			new long[] {_group1.getGroupId(), _group2.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(
+			firstName, new long[] {_group1.getGroupId(), _group2.getGroupId()});
+		_user2 = _addUser(firstName, _group1);
 
 		String filterString = StringBundler.concat(
 			"(firstName eq '", firstName, "') and ((groupIds eq '",
@@ -779,13 +713,9 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByGroupIdWithAnd() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(),
-			new long[] {_group1.getGroupId(), _group2.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(
+			firstName, new long[] {_group1.getGroupId(), _group2.getGroupId()});
+		_user2 = _addUser(firstName, _group1);
 
 		String filterString = String.format(
 			"(firstName eq '%s') and (groupId eq '%s') and (groupId eq '%s')",
@@ -805,14 +735,13 @@ public class UserODataRetrieverTest {
 
 	@Test
 	public void testGetUsersFilterByJobTitle() throws Exception {
-		_user1 = UserTestUtil.addUser(_group1.getGroupId());
+		_user1 = _addUser(_group1);
 
 		_user1.setJobTitle(RandomTestUtil.randomString());
 
 		_userLocalService.updateUser(_user1);
 
-		_user2 = UserTestUtil.addUser(
-			_group1.getGroupId(), LocaleUtil.getDefault());
+		_user2 = _addUser(_group1);
 
 		String filterString = "(jobTitle eq '" + _user1.getJobTitle() + "')";
 
@@ -830,7 +759,7 @@ public class UserODataRetrieverTest {
 
 	@Test
 	public void testGetUsersFilterByJobTitleContains() throws Exception {
-		_user1 = UserTestUtil.addUser(_group1.getGroupId());
+		_user1 = _addUser(_group1);
 
 		String jobTitlePrefix = RandomTestUtil.randomString();
 
@@ -838,8 +767,7 @@ public class UserODataRetrieverTest {
 
 		_userLocalService.updateUser(_user1);
 
-		_user2 = UserTestUtil.addUser(
-			_group1.getGroupId(), LocaleUtil.getDefault());
+		_user2 = _addUser(_group1);
 
 		List<User> users = _oDataRetriever.getResults(
 			_group1.getCompanyId(),
@@ -852,8 +780,8 @@ public class UserODataRetrieverTest {
 
 	@Test
 	public void testGetUsersFilterByLastName() throws Exception {
-		_user1 = UserTestUtil.addUser(_group1.getGroupId());
-		_user2 = UserTestUtil.addUser(_group1.getGroupId());
+		_user1 = _addUser(_group1);
+		_user2 = _addUser(_group1);
 
 		String filterString = "(lastName eq '" + _user1.getLastName() + "')";
 
@@ -873,13 +801,9 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByMultipleGroupIds() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(),
-			new long[] {_group1.getGroupId(), _group2.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(
+			firstName, new long[] {_group1.getGroupId(), _group2.getGroupId()});
+		_user2 = _addUser(firstName, _group1);
 
 		String filterString = StringBundler.concat(
 			"(firstName eq '", firstName, "') and (groupIds eq '",
@@ -902,12 +826,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByOrganizationIds() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		Organization organization = OrganizationTestUtil.addOrganization();
 
@@ -936,12 +856,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByRoleIds() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		_role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
@@ -967,13 +883,9 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByScopeGroupId() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(),
-			new long[] {_group1.getGroupId(), _group2.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(
+			firstName, new long[] {_group1.getGroupId(), _group2.getGroupId()});
+		_user2 = _addUser(firstName, _group1);
 
 		String filterString = StringBundler.concat(
 			"(firstName eq '", firstName, "') and (scopeGroupId eq '",
@@ -993,8 +905,8 @@ public class UserODataRetrieverTest {
 
 	@Test
 	public void testGetUsersFilterByScreenName() throws Exception {
-		_user1 = UserTestUtil.addUser(_group1.getGroupId());
-		_user2 = UserTestUtil.addUser(_group1.getGroupId());
+		_user1 = _addUser(_group1);
+		_user2 = _addUser(_group1);
 
 		String filterString =
 			"(screenName eq '" + _user1.getScreenName() + "')";
@@ -1015,12 +927,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByTeamIds() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		_team = _addTeam();
 
@@ -1046,12 +954,8 @@ public class UserODataRetrieverTest {
 	public void testGetUsersFilterByUserGroupIds() throws Exception {
 		String firstName = RandomTestUtil.randomString();
 
-		_user1 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
-		_user2 = UserTestUtil.addUser(
-			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
-			RandomTestUtil.randomString(), new long[] {_group1.getGroupId()});
+		_user1 = _addUser(firstName, _group1);
+		_user2 = _addUser(firstName, _group1);
 
 		_userGroup = UserGroupTestUtil.addUserGroup();
 
@@ -1075,7 +979,7 @@ public class UserODataRetrieverTest {
 
 	@Test
 	public void testGetUsersFilterByUserId() throws Exception {
-		_user1 = UserTestUtil.addUser(_group1.getGroupId());
+		_user1 = _addUser(_group1);
 
 		String filterString = "(userId eq '" + _user1.getUserId() + "')";
 
@@ -1093,8 +997,8 @@ public class UserODataRetrieverTest {
 
 	@Test
 	public void testGetUsersFilterByUserName() throws Exception {
-		_user1 = UserTestUtil.addUser(_group1.getGroupId());
-		_user2 = UserTestUtil.addUser(_group1.getGroupId());
+		_user1 = _addUser(_group1);
+		_user2 = _addUser(_group1);
 
 		String filterString =
 			"(userName eq '" + StringUtil.toLowerCase(_user1.getFullName()) +
@@ -1119,12 +1023,8 @@ public class UserODataRetrieverTest {
 
 		long groupId = _group1.getGroupId();
 
-		Locale localeDefault = LocaleUtil.getDefault();
-
 		for (int i = 0; i < MORE_THAN_10K; i++) {
-			UserTestUtil.addUser(
-				RandomTestUtil.randomString(), localeDefault, "firstName",
-				RandomTestUtil.randomString(), new long[] {groupId});
+			_addUser("firstName", new long[] {groupId});
 		}
 
 		String filterString = String.format("(firstName eq '%s')", "firstName");
@@ -1136,11 +1036,29 @@ public class UserODataRetrieverTest {
 		Assert.assertTrue(MORE_THAN_10K == users.size());
 	}
 
+	private Group _addGroup() throws Exception {
+		return GroupTestUtil.addGroup();
+	}
+
 	private Team _addTeam() throws Exception {
 		return _teamLocalService.addTeam(
 			TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private User _addUser(Group group) throws Exception {
+		return _addUser(RandomTestUtil.randomString(), group);
+	}
+
+	private User _addUser(String firstName, Group group) throws Exception {
+		return _addUser(firstName, new long[] {group.getGroupId()});
+	}
+
+	private User _addUser(String firstName, long... groupIds) throws Exception {
+		return UserTestUtil.addUser(
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(), firstName,
+			RandomTestUtil.randomString(), groupIds);
 	}
 
 	private String _toISOFormat(Instant instant) {


### PR DESCRIPTION
- LPS-139947 Created test to retrieve more than 10k users
- LPS-139947 rename
- LPS-139947 inline
- LPS-139947 Normalize user and group creation in UserODataRetrieverTest
- LPS-139947 Execute all integration tests in a new company
- LPS-139947 Create the new company with a Elasticsearch index max_result_window configuration to 10, to reproduce the issue in an easier way, with a lower number of users
- LPS-139947 Set INDEX_SEARCH_LIMIT to _ELASTICSEARCH_MAX_RESULT_WINDOW for all the UserODataRetrieverTest tests as we have changed the Elasticsearch max_result_window limit
- LPS-139947 Change test to create only 30 users as now Elasticsearch max_result_window is 10, so we will force to retrieve three pages of users
- LPS-139947 It is not necessary to create the group as it is created in the setUp(). Create a random firstName as it is done in other tests
- LPS-139947 SF
