### PR TITLE
LPS-103224_add_lambda_in_ddmIndexer_5

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Dynamic Data Mapping API
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.api
-Bundle-Version: 9.17.1
+Bundle-Version: 9.18.0
 Export-Package:\
 	com.liferay.dynamic.data.mapping.annotations,\
 	com.liferay.dynamic.data.mapping.configuration,\

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMIndexer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMIndexer.java
@@ -18,6 +18,7 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.search.BooleanQuery;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.filter.QueryFilter;
 import com.liferay.portal.search.sort.Sort;
@@ -26,6 +27,7 @@ import com.liferay.portal.search.sort.SortOrder;
 import java.io.Serializable;
 
 import java.util.Locale;
+import java.util.function.BiConsumer;
 
 /**
  * @author Alexander Chow
@@ -61,10 +63,26 @@ public interface DDMIndexer {
 			String ddmStructureFieldName, Locale locale, SortOrder sortOrder)
 		throws PortalException;
 
+	public default QueryFilter createFieldValueQueryFilter(
+			DDMStructure ddmStructure, String fieldReference, Locale locale,
+			BiConsumer<BooleanQuery, String> addQueryTermBiConsumer)
+		throws Exception {
+
+		throw new UnsupportedOperationException();
+	}
+
 	public QueryFilter createFieldValueQueryFilter(
 			DDMStructure ddmStructure, String fieldReference, Locale locale,
 			Serializable value)
 		throws Exception;
+
+	public default QueryFilter createFieldValueQueryFilter(
+			String ddmStructureFieldName, Locale locale,
+			BiConsumer<BooleanQuery, String> addQueryTermBiConsumer)
+		throws Exception {
+
+		throw new UnsupportedOperationException();
+	}
 
 	public QueryFilter createFieldValueQueryFilter(
 			String ddmStructureFieldName, Serializable ddmStructureFieldValue,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.5.0
+version 3.6.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -273,6 +273,19 @@ public class DDMIndexerImpl implements DDMIndexer {
 	@Override
 	public QueryFilter createFieldValueQueryFilter(
 			DDMStructure ddmStructure, String fieldReference, Locale locale,
+			BiConsumer<BooleanQuery, String> addQueryTermBiConsumer)
+		throws Exception {
+
+		String indexType = ddmStructure.getFieldPropertyByFieldReference(
+			fieldReference, "indexType");
+
+		return createFieldValueQueryFilter(
+			ddmStructure, fieldReference, locale, indexType,
+			addQueryTermBiConsumer);
+	}
+
+	public QueryFilter createFieldValueQueryFilter(
+			DDMStructure ddmStructure, String fieldReference, Locale locale,
 			Serializable value)
 		throws Exception {
 
@@ -281,6 +294,27 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 		return createFieldValueQueryFilter(
 			ddmStructure, fieldReference, value, locale, indexType);
+	}
+
+	public QueryFilter createFieldValueQueryFilter(
+			String ddmStructureFieldName, Locale locale,
+			BiConsumer<BooleanQuery, String> addQueryTermBiConsumer)
+		throws Exception {
+
+		String[] ddmStructureFieldNameParts = StringUtil.split(
+			ddmStructureFieldName, DDM_FIELD_SEPARATOR);
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+			GetterUtil.getLong(ddmStructureFieldNameParts[2]));
+
+		String fieldReference = StringUtil.replaceLast(
+			ddmStructureFieldNameParts[3],
+			StringPool.UNDERLINE.concat(LocaleUtil.toLanguageId(locale)),
+			StringPool.BLANK);
+
+		return createFieldValueQueryFilter(
+			ddmStructure, fieldReference, locale, ddmStructureFieldNameParts[1],
+			addQueryTermBiConsumer);
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -685,22 +685,22 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 		BooleanQuery booleanQuery = new BooleanQueryImpl();
 
-		if (!isLegacyDDMIndexFieldsEnabled()) {
-			booleanQuery.addRequiredTerm(
-				StringBundler.concat(
-					DDM_FIELD_ARRAY, StringPool.PERIOD, DDM_FIELD_NAME),
-				ddmStructureFieldName);
-
-			ddmStructureFieldName = StringBundler.concat(
-				DDM_FIELD_ARRAY, StringPool.PERIOD,
-				getValueFieldName(indexType, locale));
-		}
-
-		addQueryTermBiConsumer.accept(booleanQuery, ddmStructureFieldName);
-
 		if (isLegacyDDMIndexFieldsEnabled()) {
+			addQueryTermBiConsumer.accept(booleanQuery, ddmStructureFieldName);
+
 			return new QueryFilter(booleanQuery);
 		}
+
+		booleanQuery.addRequiredTerm(
+			StringBundler.concat(
+				DDM_FIELD_ARRAY, StringPool.PERIOD, DDM_FIELD_NAME),
+			ddmStructureFieldName);
+
+		addQueryTermBiConsumer.accept(
+			booleanQuery,
+			StringBundler.concat(
+				DDM_FIELD_ARRAY, StringPool.PERIOD,
+				getValueFieldName(indexType, locale)));
 
 		return new QueryFilter(new NestedQuery(DDM_FIELD_ARRAY, booleanQuery));
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -475,30 +475,6 @@ public class DDMIndexerImpl implements DDMIndexer {
 			DDMIndexerConfiguration.class, properties);
 	}
 
-	protected void addFieldValueRequiredTerm(
-		BooleanQuery booleanQuery, String ddmStructureFieldName,
-		String ddmStructureFieldValue, String indexType, Locale locale) {
-
-		if (isLegacyDDMIndexFieldsEnabled()) {
-			booleanQuery.addRequiredTerm(
-				ddmStructureFieldName,
-				StringPool.QUOTE + ddmStructureFieldValue + StringPool.QUOTE);
-
-			return;
-		}
-
-		booleanQuery.addRequiredTerm(
-			StringBundler.concat(
-				DDM_FIELD_ARRAY, StringPool.PERIOD, DDM_FIELD_NAME),
-			ddmStructureFieldName);
-
-		booleanQuery.addRequiredTerm(
-			StringBundler.concat(
-				DDM_FIELD_ARRAY, StringPool.PERIOD,
-				getValueFieldName(indexType, locale)),
-			StringPool.QUOTE + ddmStructureFieldValue + StringPool.QUOTE);
-	}
-
 	protected void addToDocument(
 			Document document, Field field, String indexType, String name,
 			Serializable value)
@@ -686,6 +662,17 @@ public class DDMIndexerImpl implements DDMIndexer {
 			locale = null;
 		}
 
+		if (!isLegacyDDMIndexFieldsEnabled()) {
+			booleanQuery.addRequiredTerm(
+				StringBundler.concat(
+					DDM_FIELD_ARRAY, StringPool.PERIOD, DDM_FIELD_NAME),
+				ddmStructureFieldName);
+
+			ddmStructureFieldName = StringBundler.concat(
+				DDM_FIELD_ARRAY, StringPool.PERIOD,
+				getValueFieldName(indexType, locale));
+		}
+
 		if (ddmStructureFieldValue instanceof String[]) {
 			String[] ddmStructureFieldValueArray =
 				(String[])ddmStructureFieldValue;
@@ -693,15 +680,17 @@ public class DDMIndexerImpl implements DDMIndexer {
 			for (String ddmStructureFieldValueString :
 					ddmStructureFieldValueArray) {
 
-				addFieldValueRequiredTerm(
-					booleanQuery, ddmStructureFieldName,
-					ddmStructureFieldValueString, indexType, locale);
+				booleanQuery.addRequiredTerm(
+					ddmStructureFieldName,
+					StringPool.QUOTE + ddmStructureFieldValueString +
+						StringPool.QUOTE);
 			}
 		}
 		else {
-			addFieldValueRequiredTerm(
-				booleanQuery, ddmStructureFieldName,
-				String.valueOf(ddmStructureFieldValue), indexType, locale);
+			booleanQuery.addRequiredTerm(
+				ddmStructureFieldName,
+				StringPool.QUOTE + String.valueOf(ddmStructureFieldValue) +
+					StringPool.QUOTE);
 		}
 
 		if (isLegacyDDMIndexFieldsEnabled()) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -280,9 +280,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 			fieldReference, "indexType");
 
 		return createFieldValueQueryFilter(
-			ddmStructure,
-			encodeName(ddmStructure.getStructureId(), fieldReference, locale),
-			value, fieldReference, indexType, locale);
+			ddmStructure, fieldReference, value, locale, indexType);
 	}
 
 	@Override
@@ -303,8 +301,8 @@ public class DDMIndexerImpl implements DDMIndexer {
 			StringPool.BLANK);
 
 		return createFieldValueQueryFilter(
-			ddmStructure, ddmStructureFieldName, ddmStructureFieldValue,
-			fieldReference, ddmStructureFieldNameParts[1], locale);
+			ddmStructure, fieldReference, ddmStructureFieldValue, locale,
+			ddmStructureFieldNameParts[1]);
 	}
 
 	@Override
@@ -639,49 +637,17 @@ public class DDMIndexerImpl implements DDMIndexer {
 	}
 
 	protected QueryFilter createFieldValueQueryFilter(
-			DDMStructure ddmStructure, String ddmStructureFieldName,
-			Serializable ddmStructureFieldValue, String fieldReference,
-			String indexType, Locale locale)
+			DDMStructure ddmStructure, String fieldReference, Locale locale,
+			String indexType,
+			BiConsumer<BooleanQuery, String> addQueryTermBiConsumer)
 		throws Exception {
 
-		boolean localizable = false;
-
-		if (ddmStructure.hasFieldByFieldReference(fieldReference)) {
-			ddmStructureFieldValue = _ddm.getIndexedFieldValue(
-				ddmStructureFieldValue,
-				ddmStructure.getFieldPropertyByFieldReference(
-					fieldReference, "type"));
-
-			localizable = GetterUtil.getBoolean(
-				ddmStructure.getFieldPropertyByFieldReference(
-					fieldReference, "localizable"));
-		}
-
-		if (!localizable) {
+		if (!_isLocalizableField(ddmStructure, fieldReference)) {
 			locale = null;
 		}
 
-		final Serializable fieldValue = ddmStructureFieldValue;
-
-		BiConsumer<BooleanQuery, String> addQueryTermBiConsumer =
-			(booleanQuery, fieldName) -> {
-				if (fieldValue instanceof String[]) {
-					String[] fieldValueArray = (String[])fieldValue;
-
-					for (String fieldValueString : fieldValueArray) {
-						booleanQuery.addRequiredTerm(
-							fieldName,
-							StringPool.QUOTE + fieldValueString +
-								StringPool.QUOTE);
-					}
-				}
-				else {
-					booleanQuery.addRequiredTerm(
-						fieldName,
-						StringPool.QUOTE + String.valueOf(fieldValue) +
-							StringPool.QUOTE);
-				}
-			};
+		String ddmStructureFieldName = encodeName(
+			ddmStructure.getStructureId(), fieldReference, locale, indexType);
 
 		BooleanQuery booleanQuery = new BooleanQueryImpl();
 
@@ -703,6 +669,47 @@ public class DDMIndexerImpl implements DDMIndexer {
 				getValueFieldName(indexType, locale)));
 
 		return new QueryFilter(new NestedQuery(DDM_FIELD_ARRAY, booleanQuery));
+	}
+
+	protected QueryFilter createFieldValueQueryFilter(
+			DDMStructure ddmStructure, String fieldReference,
+			Serializable ddmStructureFieldValue, Locale locale,
+			String indexType)
+		throws Exception {
+
+		if (ddmStructure.hasFieldByFieldReference(fieldReference)) {
+			ddmStructureFieldValue = _ddm.getIndexedFieldValue(
+				ddmStructureFieldValue,
+				ddmStructure.getFieldPropertyByFieldReference(
+					fieldReference, "type"));
+		}
+
+		if (!_isLocalizableField(ddmStructure, fieldReference)) {
+			locale = null;
+		}
+
+		final Serializable fieldValue = ddmStructureFieldValue;
+
+		return createFieldValueQueryFilter(
+			ddmStructure, fieldReference, locale, indexType,
+			(booleanQuery, fieldName) -> {
+				if (fieldValue instanceof String[]) {
+					String[] fieldValueArray = (String[])fieldValue;
+
+					for (String fieldValueString : fieldValueArray) {
+						booleanQuery.addRequiredTerm(
+							fieldName,
+							StringPool.QUOTE + fieldValueString +
+								StringPool.QUOTE);
+					}
+				}
+				else {
+					booleanQuery.addRequiredTerm(
+						fieldName,
+						StringPool.QUOTE + String.valueOf(fieldValue) +
+							StringPool.QUOTE);
+				}
+			});
 	}
 
 	protected String encodeName(
@@ -818,6 +825,19 @@ public class DDMIndexerImpl implements DDMIndexer {
 		}
 
 		return sortableValue;
+	}
+
+	private boolean _isLocalizableField(
+			DDMStructure ddmStructure, String fieldReference)
+		throws Exception {
+
+		if (!ddmStructure.hasFieldByFieldReference(fieldReference)) {
+			return false;
+		}
+
+		return GetterUtil.getBoolean(
+			ddmStructure.getFieldPropertyByFieldReference(
+				fieldReference, "localizable"));
 	}
 
 	private static final int _SORTABLE_TEXT_FIELDS_TRUNCATED_LENGTH =

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -722,28 +722,28 @@ public class DDMIndexerImpl implements DDMIndexer {
 			locale = null;
 		}
 
-		final Serializable fieldValue = ddmStructureFieldValue;
+		if (ddmStructureFieldValue instanceof String[]) {
+			final String[] fieldValueArray = (String[])ddmStructureFieldValue;
 
-		return createFieldValueQueryFilter(
-			ddmStructure, fieldReference, locale, indexType,
-			(booleanQuery, fieldName) -> {
-				if (fieldValue instanceof String[]) {
-					String[] fieldValueArray = (String[])fieldValue;
-
+			return createFieldValueQueryFilter(
+				ddmStructure, fieldReference, locale, indexType,
+				(booleanQuery, fieldName) -> {
 					for (String fieldValueString : fieldValueArray) {
 						booleanQuery.addRequiredTerm(
 							fieldName,
 							StringPool.QUOTE + fieldValueString +
 								StringPool.QUOTE);
 					}
-				}
-				else {
-					booleanQuery.addRequiredTerm(
-						fieldName,
-						StringPool.QUOTE + String.valueOf(fieldValue) +
-							StringPool.QUOTE);
-				}
-			});
+				});
+		}
+
+		final String fieldValueString = String.valueOf(ddmStructureFieldValue);
+
+		return createFieldValueQueryFilter(
+			ddmStructure, fieldReference, locale, indexType,
+			(booleanQuery, fieldName) -> booleanQuery.addRequiredTerm(
+				fieldName,
+				StringPool.QUOTE + fieldValueString + StringPool.QUOTE));
 	}
 
 	protected String encodeName(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -477,8 +477,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 	protected void addFieldValueRequiredTerm(
 		BooleanQuery booleanQuery, String ddmStructureFieldName,
-		String ddmStructureFieldValue, String indexType, Locale locale,
-		boolean localizable) {
+		String ddmStructureFieldValue, String indexType, Locale locale) {
 
 		if (isLegacyDDMIndexFieldsEnabled()) {
 			booleanQuery.addRequiredTerm(
@@ -492,10 +491,6 @@ public class DDMIndexerImpl implements DDMIndexer {
 			StringBundler.concat(
 				DDM_FIELD_ARRAY, StringPool.PERIOD, DDM_FIELD_NAME),
 			ddmStructureFieldName);
-
-		if (!localizable) {
-			locale = null;
-		}
 
 		booleanQuery.addRequiredTerm(
 			StringBundler.concat(
@@ -687,6 +682,10 @@ public class DDMIndexerImpl implements DDMIndexer {
 					fieldReference, "localizable"));
 		}
 
+		if (!localizable) {
+			locale = null;
+		}
+
 		if (ddmStructureFieldValue instanceof String[]) {
 			String[] ddmStructureFieldValueArray =
 				(String[])ddmStructureFieldValue;
@@ -696,15 +695,13 @@ public class DDMIndexerImpl implements DDMIndexer {
 
 				addFieldValueRequiredTerm(
 					booleanQuery, ddmStructureFieldName,
-					ddmStructureFieldValueString, indexType, locale,
-					localizable);
+					ddmStructureFieldValueString, indexType, locale);
 			}
 		}
 		else {
 			addFieldValueRequiredTerm(
 				booleanQuery, ddmStructureFieldName,
-				String.valueOf(ddmStructureFieldValue), indexType, locale,
-				localizable);
+				String.valueOf(ddmStructureFieldValue), indexType, locale);
 		}
 
 		if (isLegacyDDMIndexFieldsEnabled()) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -737,7 +737,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 				});
 		}
 
-		final String fieldValueString = String.valueOf(ddmStructureFieldValue);
+		String fieldValueString = String.valueOf(ddmStructureFieldValue);
 
 		return createFieldValueQueryFilter(
 			ddmStructure, fieldReference, locale, indexType,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -75,6 +75,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -643,8 +644,6 @@ public class DDMIndexerImpl implements DDMIndexer {
 			String indexType, Locale locale)
 		throws Exception {
 
-		BooleanQuery booleanQuery = new BooleanQueryImpl();
-
 		boolean localizable = false;
 
 		if (ddmStructure.hasFieldByFieldReference(fieldReference)) {
@@ -662,6 +661,30 @@ public class DDMIndexerImpl implements DDMIndexer {
 			locale = null;
 		}
 
+		final Serializable fieldValue = ddmStructureFieldValue;
+
+		BiConsumer<BooleanQuery, String> addQueryTermBiConsumer =
+			(booleanQuery, fieldName) -> {
+				if (fieldValue instanceof String[]) {
+					String[] fieldValueArray = (String[])fieldValue;
+
+					for (String fieldValueString : fieldValueArray) {
+						booleanQuery.addRequiredTerm(
+							fieldName,
+							StringPool.QUOTE + fieldValueString +
+								StringPool.QUOTE);
+					}
+				}
+				else {
+					booleanQuery.addRequiredTerm(
+						fieldName,
+						StringPool.QUOTE + String.valueOf(fieldValue) +
+							StringPool.QUOTE);
+				}
+			};
+
+		BooleanQuery booleanQuery = new BooleanQueryImpl();
+
 		if (!isLegacyDDMIndexFieldsEnabled()) {
 			booleanQuery.addRequiredTerm(
 				StringBundler.concat(
@@ -673,25 +696,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 				getValueFieldName(indexType, locale));
 		}
 
-		if (ddmStructureFieldValue instanceof String[]) {
-			String[] ddmStructureFieldValueArray =
-				(String[])ddmStructureFieldValue;
-
-			for (String ddmStructureFieldValueString :
-					ddmStructureFieldValueArray) {
-
-				booleanQuery.addRequiredTerm(
-					ddmStructureFieldName,
-					StringPool.QUOTE + ddmStructureFieldValueString +
-						StringPool.QUOTE);
-			}
-		}
-		else {
-			booleanQuery.addRequiredTerm(
-				ddmStructureFieldName,
-				StringPool.QUOTE + String.valueOf(ddmStructureFieldValue) +
-					StringPool.QUOTE);
-		}
+		addQueryTermBiConsumer.accept(booleanQuery, ddmStructureFieldName);
 
 		if (isLegacyDDMIndexFieldsEnabled()) {
 			return new QueryFilter(booleanQuery);


### PR DESCRIPTION
- LPS-103224 Simplify localizable check
- LPS-103224 Inline addFieldValueRequiredTerm method
- LPS-103224 Extract code to BiConsumer lambda
- LPS-103224 Simplify with only one isLegacyDDMIndexFieldsEnabled if block
- LPS-103224 Create a new createFieldValueQueryFilter method with a BiConsumer<BooleanQuery, String> parameter
- LPS-103224 Add new createFieldValueQueryFilter public methods with the BiConsumer parameter
- LPS-103224 Split current biconsumer lambda in two smaller ones
- LPS-103224 SF
- LPS-103224 Semver
