### PR TITLE
[TS] LPS-142128 A data inconsistency in some page permissions causes Liferay to stop working, an error is displayed on the browser and you are not able to login

### DIFF
--- a/portal-impl/src/com/liferay/portal/template/TemplateContextHelper.java
+++ b/portal-impl/src/com/liferay/portal/template/TemplateContextHelper.java
@@ -22,7 +22,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.audit.AuditMessageFactoryUtil;
 import com.liferay.portal.kernel.audit.AuditRouterUtil;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.image.ImageToolUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -344,8 +343,8 @@ public class TemplateContextHelper {
 
 					contextObjects.put("navItems", navItems);
 				}
-				catch (PortalException portalException) {
-					_log.error(portalException, portalException);
+				catch (Exception exception) {
+					_log.error(exception, exception);
 				}
 			}
 


### PR DESCRIPTION
A data inconsistency in some page permissions causes Liferay to stop working, an error is displayed on the browser and you are not able to login

This issue was reported by a final customer: as their login option was blocked and the system was not working, before opening a ticket to support they started manually updating the database to unlock the situation.
We should make the product more robust to this inconsistency to avoid that unexpected errors completely blocks the user interface.

The root cause of the user interface error is in the TemplateContextHelper class, as it is including in the context object a navItems that contains all the Navigation items, but in case it fails, the error is not catch and it is directly displayed to the final user.

Just changing the exception catch from PortalException to Exception will avoid the error in the user interface but it will be written to the log file.

I am doing an additional investigation to find the real root cause of the data inconsistency, but I think it worths making the product more robust in case there is a data problem to avoid blocking the whole access to the system.
