### PR TITLE
orphan_detection_2

### DIFF
--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/exportimport/test/AssetPublisherExportImportTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/exportimport/test/AssetPublisherExportImportTest.java
@@ -1208,7 +1208,7 @@ public class AssetPublisherExportImportTest
 				" does not belong to group ", expectedGroupId),
 			expectedGroupId, importedVocabulary.getGroupId());
 
-		_assetVocabularyLocalService.deleteAssetVocabulary(assetVocabulary);
+		_assetVocabularyLocalService.deleteVocabulary(assetVocabulary);
 	}
 
 	private static Configuration _assetPublisherWebConfiguration;

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/internal/exportimport/portlet/preferences/processor/test/AssetPublisherExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/internal/exportimport/portlet/preferences/processor/test/AssetPublisherExportImportPortletPreferencesProcessorTest.java
@@ -123,7 +123,7 @@ public class AssetPublisherExportImportPortletPreferencesProcessorTest {
 		// Update asset vocabulary to have a different primary key. We will swap
 		// to the new one and verify it.
 
-		AssetVocabularyLocalServiceUtil.deleteAssetVocabulary(
+		AssetVocabularyLocalServiceUtil.deleteVocabulary(
 			assetVocabulary.getVocabularyId());
 
 		assetVocabulary = AssetTestUtil.addVocabulary(_group.getGroupId());
@@ -178,7 +178,7 @@ public class AssetPublisherExportImportPortletPreferencesProcessorTest {
 		// Update asset vocabulary to have a different primary key. We will swap
 		// to the new one and verify it.
 
-		AssetCategoryLocalServiceUtil.deleteAssetCategory(
+		AssetCategoryLocalServiceUtil.deleteCategory(
 			assetCategory.getCategoryId());
 
 		assetCategory = AssetTestUtil.addCategory(

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/closure/test/CTClosureFactoryImplTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/closure/test/CTClosureFactoryImplTest.java
@@ -194,8 +194,7 @@ public class CTClosureFactoryImplTest {
 					"CTCollectionLocalServiceImpl",
 				LoggerTestUtil.WARN)) {
 
-			_ctCollectionLocalService.deleteCTCollection(
-				_ctCollection.getCtCollectionId());
+			_ctCollectionLocalService.deleteCTCollection(_ctCollection);
 		}
 
 		_db.runSQL("drop table GrandParentTable");

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/test/CPDisplayLayoutLocalServiceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/test/CPDisplayLayoutLocalServiceTest.java
@@ -157,7 +157,7 @@ public class CPDisplayLayoutLocalServiceTest {
 
 		Assert.assertEquals(
 			2, _cpDisplayLayoutLocalService.getCPDisplayLayoutsCount());
-		AssetCategoryLocalServiceUtil.deleteAssetCategory(assetCategory);
+		AssetCategoryLocalServiceUtil.deleteCategory(assetCategory);
 		Assert.assertEquals(
 			0, _cpDisplayLayoutLocalService.getCPDisplayLayoutsCount());
 	}

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/util/test/CPDefinitionHelperTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/util/test/CPDefinitionHelperTest.java
@@ -213,7 +213,7 @@ public class CPDefinitionHelperTest {
 		Assert.assertTrue(
 			actualCPDefinitionIds.containsAll(cpDefinitionIdsList));
 
-		AssetCategoryLocalServiceUtil.deleteAssetCategory(
+		AssetCategoryLocalServiceUtil.deleteCategory(
 			assetCategory.getCategoryId());
 	}
 

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletGetPropsTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletGetPropsTest.java
@@ -166,7 +166,7 @@ public class ContentDashboardAdminPortletGetPropsTest {
 				String.valueOf(props.get("vocabularies")));
 		}
 		finally {
-			_assetVocabularyLocalService.deleteAssetVocabulary(assetVocabulary);
+			_assetVocabularyLocalService.deleteVocabulary(assetVocabulary);
 		}
 	}
 
@@ -483,9 +483,8 @@ public class ContentDashboardAdminPortletGetPropsTest {
 				String.valueOf(props.get("vocabularies")));
 		}
 		finally {
-			_assetVocabularyLocalService.deleteAssetVocabulary(assetVocabulary);
-			_assetVocabularyLocalService.deleteAssetVocabulary(
-				childAssetVocabulary);
+			_assetVocabularyLocalService.deleteVocabulary(assetVocabulary);
+			_assetVocabularyLocalService.deleteVocabulary(childAssetVocabulary);
 		}
 	}
 
@@ -592,9 +591,8 @@ public class ContentDashboardAdminPortletGetPropsTest {
 				String.valueOf(props.get("vocabularies")));
 		}
 		finally {
-			_assetVocabularyLocalService.deleteAssetVocabulary(assetVocabulary);
-			_assetVocabularyLocalService.deleteAssetVocabulary(
-				childAssetVocabulary);
+			_assetVocabularyLocalService.deleteVocabulary(assetVocabulary);
+			_assetVocabularyLocalService.deleteVocabulary(childAssetVocabulary);
 		}
 	}
 

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletTest.java
@@ -182,8 +182,8 @@ public class ContentDashboardAdminPortletTest {
 						audienceAssetVocabulary, childAssetVocabulary)));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(assetCategory);
-			_assetCategoryLocalService.deleteAssetCategory(childAssetCategory);
+			_assetCategoryLocalService.deleteCategory(assetCategory);
+			_assetCategoryLocalService.deleteCategory(childAssetCategory);
 		}
 	}
 
@@ -230,7 +230,7 @@ public class ContentDashboardAdminPortletTest {
 				_getAuditGraphTitle(_getMockLiferayPortletRenderRequest()));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(assetCategory);
+			_assetCategoryLocalService.deleteCategory(assetCategory);
 		}
 	}
 
@@ -367,7 +367,7 @@ public class ContentDashboardAdminPortletTest {
 					LocaleUtil.US));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory.getCategoryId());
 		}
 	}
@@ -699,7 +699,7 @@ public class ContentDashboardAdminPortletTest {
 					LocaleUtil.US));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory.getCategoryId());
 		}
 	}
@@ -794,9 +794,9 @@ public class ContentDashboardAdminPortletTest {
 					LocaleUtil.US));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory1.getCategoryId());
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory2.getCategoryId());
 		}
 	}
@@ -1030,9 +1030,9 @@ public class ContentDashboardAdminPortletTest {
 					LocaleUtil.US));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory1.getCategoryId());
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory2.getCategoryId());
 		}
 	}
@@ -1321,7 +1321,7 @@ public class ContentDashboardAdminPortletTest {
 			Assert.assertEquals(assetCategory, assetCategories.get(0));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory.getCategoryId());
 		}
 	}
@@ -1461,8 +1461,8 @@ public class ContentDashboardAdminPortletTest {
 					String.valueOf(childAssetVocabulary.getVocabularyId())));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(assetCategory);
-			_assetCategoryLocalService.deleteAssetCategory(childAssetCategory);
+			_assetCategoryLocalService.deleteCategory(assetCategory);
+			_assetCategoryLocalService.deleteCategory(childAssetCategory);
 		}
 	}
 
@@ -1501,7 +1501,7 @@ public class ContentDashboardAdminPortletTest {
 					String.valueOf(stageAssetVocabulary.getVocabularyId())));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(assetCategory);
+			_assetCategoryLocalService.deleteCategory(assetCategory);
 		}
 	}
 
@@ -1548,8 +1548,8 @@ public class ContentDashboardAdminPortletTest {
 					String.valueOf(assetVocabulary.getVocabularyId())));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(assetCategory);
-			_assetCategoryLocalService.deleteAssetCategory(childAssetCategory);
+			_assetCategoryLocalService.deleteCategory(assetCategory);
+			_assetCategoryLocalService.deleteCategory(childAssetCategory);
 		}
 	}
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
@@ -146,7 +146,7 @@ public class DepotEntryLocalServiceTest {
 	public void testDeleteDepotEntry() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry("name", "description");
 
-		_depotEntryLocalService.deleteDepotEntry(depotEntry);
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
 
 		_depotEntries.remove(depotEntry);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryMetadataDDMStructureFixture.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryMetadataDDMStructureFixture.java
@@ -145,7 +145,7 @@ public class DLFileEntryMetadataDDMStructureFixture {
 
 	protected void deleteAllFileEntryTypes() throws PortalException {
 		for (DLFileEntryType dlFileEntryType : _fileEntryTypes) {
-			_dlFileEntryTypeLocalService.deleteDLFileEntryType(dlFileEntryType);
+			_dlFileEntryTypeLocalService.deleteFileEntryType(dlFileEntryType);
 		}
 
 		_fileEntryTypes.clear();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
@@ -409,7 +409,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 
 	@Override
 	protected void deleteBaseModel(long primaryKey) throws Exception {
-		DLFileEntryLocalServiceUtil.deleteDLFileEntry(primaryKey);
+		DLFileEntryLocalServiceUtil.deleteFileEntry(primaryKey);
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
@@ -206,7 +206,7 @@ public class DLFileEntryTypeServiceTest {
 
 		Assert.assertTrue(hasUserLocale);
 
-		DLFileEntryTypeLocalServiceUtil.deleteDLFileEntryType(dlFileEntryType);
+		DLFileEntryTypeLocalServiceUtil.deleteFileEntryType(dlFileEntryType);
 	}
 
 	@Test

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionLocalServiceTest.java
@@ -91,9 +91,8 @@ public class DLFileVersionLocalServiceTest {
 				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 				dlFileEntry.getName(), "1.0"));
 
-		_dlFileVersionLocalService.deleteDLFileVersion(
-			_dlFileVersionLocalService.getFileVersion(
-				fileEntry.getFileEntryId(), "1.0"));
+		_dlFileEntryLocalService.deleteFileVersion(
+			TestPropsValues.getUserId(), fileEntry.getFileEntryId(), "1.0");
 
 		Assert.assertFalse(
 			DLStoreUtil.hasFile(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
@@ -127,8 +127,10 @@ public class DDMFormInstanceTestUtil {
 		return ddmFormValues;
 	}
 
-	public static void deleteDDMFormInstance(DDMFormInstance ddmFormInstance) {
-		DDMFormInstanceLocalServiceUtil.deleteDDMFormInstance(ddmFormInstance);
+	public static void deleteDDMFormInstance(DDMFormInstance ddmFormInstance)
+		throws PortalException {
+
+		DDMFormInstanceLocalServiceUtil.deleteFormInstance(ddmFormInstance);
 	}
 
 	public static DDMFormInstance updateDDMFormInstance(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
@@ -69,6 +69,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
@@ -169,11 +170,20 @@ public class DDMFormValuesExportImportContentProcessorTest {
 		_journalArticleLocalService.deleteArticles(_liveGroup.getGroupId());
 
 		if (_ddmTemplate != null) {
-			_ddmTemplateLocalService.deleteDDMTemplate(_ddmTemplate);
+			_ddmTemplateLocalService.deleteTemplate(_ddmTemplate);
 		}
 
 		if (_ddmStructure != null) {
-			_ddmStructureLocalService.deleteDDMStructure(_ddmStructure);
+			boolean deleteInProcess = GroupThreadLocal.isDeleteInProcess();
+
+			try {
+				GroupThreadLocal.setDeleteInProcess(true);
+
+				_ddmStructureLocalService.deleteStructure(_ddmStructure);
+			}
+			finally {
+				GroupThreadLocal.setDeleteInProcess(deleteInProcess);
+			}
 		}
 	}
 
@@ -229,7 +239,7 @@ public class DDMFormValuesExportImportContentProcessorTest {
 
 		newDLFileEntry.setUuid(_fileEntry.getUuid());
 
-		_dlFileEntryLocalService.deleteDLFileEntry(fileEntryId);
+		_dlFileEntryLocalService.deleteFileEntry(fileEntryId);
 
 		_dlFileEntryLocalService.updateDLFileEntry(newDLFileEntry);
 
@@ -250,7 +260,7 @@ public class DDMFormValuesExportImportContentProcessorTest {
 
 		long newDLFileEntryId = newDLFileEntry.getFileEntryId();
 
-		_dlFileEntryLocalService.deleteDLFileEntry(newDLFileEntry);
+		_dlFileEntryLocalService.deleteFileEntry(newDLFileEntry);
 
 		Assert.assertEquals(newDLFileEntryId, jsonObject2.getLong("classPK"));
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMFormInstanceReportLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMFormInstanceReportLocalServiceTest.java
@@ -127,9 +127,7 @@ public class DDMFormInstanceReportLocalServiceTest
 
 		Assert.assertNotNull(ddmFormInstanceReport);
 
-		_ddmFormInstance =
-			DDMFormInstanceLocalServiceUtil.deleteDDMFormInstance(
-				_ddmFormInstance);
+		DDMFormInstanceTestUtil.deleteDDMFormInstance(_ddmFormInstance);
 
 		_ddmFormInstanceReportLocalService.
 			getFormInstanceReportByFormInstanceId(
@@ -168,7 +166,7 @@ public class DDMFormInstanceReportLocalServiceTest
 		DDMFormInstanceRecord ddmFormInstanceRecord =
 			createDDMFormInstanceRecord();
 
-		_ddmFormInstanceRecordLocalService.deleteDDMFormInstanceRecord(
+		_ddmFormInstanceRecordLocalService.deleteFormInstanceRecord(
 			ddmFormInstanceRecord);
 
 		DDMFormInstanceReport ddmFormInstanceReport =

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
@@ -755,7 +755,7 @@ public class DDMStructureLocalServiceTest extends BaseDDMServiceTestCase {
 
 		PermissionThreadLocal.setPermissionChecker(originalPermissionChecker);
 
-		DDMStructureLocalServiceUtil.deleteDDMStructure(structure);
+		DDMStructureLocalServiceUtil.deleteStructure(structure);
 
 		UserLocalServiceUtil.deleteUser(user);
 	}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/info/collection/provider/test/DDMStructureRelatedInfoCollectionProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/info/collection/provider/test/DDMStructureRelatedInfoCollectionProviderTest.java
@@ -77,7 +77,7 @@ public class DDMStructureRelatedInfoCollectionProviderTest {
 		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
 			_group.getGroupId(), JournalArticle.class.getName());
 
-		_ddmStructureLocalService.deleteDDMStructure(ddmStructure);
+		_ddmStructureLocalService.deleteStructure(ddmStructure);
 
 		RelatedInfoItemCollectionProvider<?, ?>
 			relatedInfoItemCollectionProvider =

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -406,6 +407,11 @@ public class JournalArticleLocalServiceTest {
 				PortalUtil.getClassNameId(JournalArticle.class),
 				curArticle.getPrimaryKey());
 
+			_resourceLocalService.deleteResource(
+				curArticle.getCompanyId(), JournalArticle.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				curArticle.getResourcePrimKey());
+
 			_journalArticleLocalService.deleteJournalArticle(
 				curArticle.getPrimaryKey());
 		}
@@ -560,6 +566,9 @@ public class JournalArticleLocalServiceTest {
 
 	@Inject
 	private Portal _portal;
+
+	@Inject
+	private ResourceLocalService _resourceLocalService;
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalTestUtilTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalTestUtilTest.java
@@ -243,7 +243,7 @@ public class JournalTestUtilTest {
 				ddmStructure.getStructureKey(), null,
 				LocaleUtil.getSiteDefault()));
 
-		DDMStructureLocalServiceUtil.deleteDDMStructure(ddmStructure);
+		DDMStructureLocalServiceUtil.deleteStructure(ddmStructure);
 
 		try {
 			Assert.assertNull(

--- a/modules/apps/segments/segments-context-vocabulary-test/src/testIntegration/java/com/liferay/segments/context/vocabulary/internal/options/provider/test/AssetVocabularyConfigurationOptionsProviderTest.java
+++ b/modules/apps/segments/segments-context-vocabulary-test/src/testIntegration/java/com/liferay/segments/context/vocabulary/internal/options/provider/test/AssetVocabularyConfigurationOptionsProviderTest.java
@@ -79,7 +79,7 @@ public class AssetVocabularyConfigurationOptionsProviderTest {
 				).isPresent());
 		}
 		finally {
-			_assetVocabularyLocalService.deleteAssetVocabulary(
+			_assetVocabularyLocalService.deleteVocabulary(
 				assetVocabulary.getVocabularyId());
 		}
 	}

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/search/test/WikiPageSearchTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/search/test/WikiPageSearchTest.java
@@ -133,7 +133,9 @@ public class WikiPageSearchTest extends BaseSearchTestCase {
 
 	@Override
 	protected void deleteBaseModel(long primaryKey) throws Exception {
-		WikiPageLocalServiceUtil.deleteWikiPage(primaryKey);
+		WikiPage page = WikiPageLocalServiceUtil.getPageByPageId(primaryKey);
+
+		WikiPageLocalServiceUtil.deletePage(page);
 	}
 
 	@Override

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 10.1.5
+Bundle-Version: 10.2.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/OrphanDetectionTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/OrphanDetectionTestRule.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.test.rule;
+
+import com.liferay.petra.io.unsync.UnsyncPrintWriter;
+import com.liferay.petra.io.unsync.UnsyncStringWriter;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.orm.ORMException;
+import com.liferay.portal.kernel.dao.orm.Session;
+import com.liferay.portal.kernel.dao.orm.SessionCustomizer;
+import com.liferay.portal.kernel.dao.orm.SessionWrapper;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ShardedModel;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.transaction.TransactionAttribute;
+import com.liferay.portal.kernel.transaction.TransactionLifecycleListener;
+import com.liferay.portal.kernel.transaction.TransactionStatus;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.Assert;
+import org.junit.runner.Description;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Jorge Díaz
+ */
+public class OrphanDetectionTestRule
+	extends MethodTestRule<List<ServiceRegistration<?>>> {
+
+	public static final OrphanDetectionTestRule INSTANCE =
+		new OrphanDetectionTestRule();
+
+	@Override
+	protected void afterMethod(
+			Description description,
+			List<ServiceRegistration<?>> serviceRegistrations, Object target)
+		throws Throwable {
+
+		for (ServiceRegistration<?> serviceRegistration :
+				serviceRegistrations) {
+
+			serviceRegistration.unregister();
+		}
+	}
+
+	@Override
+	protected List<ServiceRegistration<?>> beforeMethod(
+			Description description, Object target)
+		throws Throwable {
+
+		Stack<Map<BaseModel<?>, String>> recordsStack = new Stack<>();
+
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		return ListUtil.fromArray(
+			bundleContext.registerService(
+				SessionCustomizer.class,
+				new OrphanDetectionSessionCustomizer(recordsStack), null),
+			bundleContext.registerService(
+				TransactionLifecycleListener.class,
+				new OrphanDetectionTransactionLifecycleListener(recordsStack),
+				null));
+	}
+
+	private OrphanDetectionTestRule() {
+	}
+
+	private static class OrphanDetectionSessionCustomizer
+		implements SessionCustomizer {
+
+		@Override
+		public Session customize(Session session) {
+			return new OrphanDetectionSessionWrapper(session, _recordsStack);
+		}
+
+		private OrphanDetectionSessionCustomizer(
+			Stack<Map<BaseModel<?>, String>> recordsStack) {
+
+			_recordsStack = recordsStack;
+		}
+
+		private Stack<Map<BaseModel<?>, String>> _recordsStack;
+
+	}
+
+	private static class OrphanDetectionSessionWrapper extends SessionWrapper {
+
+		@Override
+		public void delete(Object object) throws ORMException {
+			super.delete(object);
+
+			if (object instanceof BaseModel<?>) {
+				_record(object);
+			}
+		}
+
+		private OrphanDetectionSessionWrapper(
+			Session session, Stack<Map<BaseModel<?>, String>> recordsStack) {
+
+			super(session);
+
+			_recordsStack = recordsStack;
+		}
+
+		private void _record(Object object) {
+			if (_recordsStack.isEmpty()) {
+				return;
+			}
+
+			BaseModel<?> baseModel = (BaseModel<?>)object;
+
+			if (baseModel.isNew()) {
+				return;
+			}
+
+			UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
+
+			Exception exception = new Exception();
+
+			exception.printStackTrace(
+				new UnsyncPrintWriter(unsyncStringWriter));
+
+			Map<BaseModel<?>, String> records = _recordsStack.peek();
+
+			records.put(baseModel, unsyncStringWriter.toString());
+		}
+
+		private Stack<Map<BaseModel<?>, String>> _recordsStack;
+
+	}
+
+	private static class OrphanDetectionTransactionLifecycleListener
+		implements TransactionLifecycleListener {
+
+		@Override
+		public void committed(
+			TransactionAttribute transactionAttribute,
+			TransactionStatus transactionStatus) {
+
+			Map<BaseModel<?>, String> records = _recordsStack.pop();
+
+			for (Map.Entry<BaseModel<?>, String> entry : records.entrySet()) {
+				BaseModel<?> baseModel = entry.getKey();
+
+				if (!(baseModel instanceof ShardedModel)) {
+					continue;
+				}
+
+				ShardedModel shardedModel = (ShardedModel)baseModel;
+
+				int count =
+					ResourcePermissionLocalServiceUtil.
+						getResourcePermissionsCount(
+							shardedModel.getCompanyId(),
+							baseModel.getModelClassName(),
+							ResourceConstants.SCOPE_INDIVIDUAL,
+							String.valueOf(baseModel.getPrimaryKeyObj()));
+
+				Assert.assertEquals(
+					StringBundler.concat(
+						"Orphan ResourcePermission after the deletion of ",
+						baseModel.getModelClassName(), ": ", baseModel,
+						" with backtraceInfo ", entry.getValue()),
+					0, count);
+			}
+		}
+
+		@Override
+		public void created(
+			TransactionAttribute transactionAttribute,
+			TransactionStatus transactionStatus) {
+
+			_recordsStack.push(new ConcurrentHashMap<>());
+		}
+
+		@Override
+		public void rollbacked(
+			TransactionAttribute transactionAttribute,
+			TransactionStatus transactionStatus, Throwable throwable) {
+
+			_recordsStack.pop();
+		}
+
+		private OrphanDetectionTransactionLifecycleListener(
+			Stack<Map<BaseModel<?>, String>> recordsStack) {
+
+			_recordsStack = recordsStack;
+		}
+
+		private Stack<Map<BaseModel<?>, String>> _recordsStack;
+
+	}
+
+}

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/OrphanDetectionTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/OrphanDetectionTestRule.java
@@ -21,11 +21,19 @@ import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.SessionCustomizer;
 import com.liferay.portal.kernel.dao.orm.SessionWrapper;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistryUtil;
+import com.liferay.portal.kernel.service.PersistedResourcedModelLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.transaction.TransactionAttribute;
 import com.liferay.portal.kernel.transaction.TransactionLifecycleListener;
 import com.liferay.portal.kernel.transaction.TransactionStatus;
@@ -160,6 +168,9 @@ public class OrphanDetectionTestRule
 
 			Map<BaseModel<?>, String> records = _recordsStack.pop();
 
+			Map<String, PersistedModelLocalService>
+				persistedModelLocalServices = _getPersistedModelLocalServices();
+
 			for (Map.Entry<BaseModel<?>, String> entry : records.entrySet()) {
 				BaseModel<?> baseModel = entry.getKey();
 
@@ -183,6 +194,17 @@ public class OrphanDetectionTestRule
 						baseModel.getModelClassName(), ": ", baseModel,
 						" with backtraceInfo ", entry.getValue()),
 					0, count);
+
+				if (baseModel instanceof ResourcedModel) {
+					try {
+						_checkResourceModelResourcePermissions(
+							baseModel, entry.getValue(),
+							persistedModelLocalServices);
+					}
+					catch (PortalException portalException) {
+						throw new SystemException(portalException);
+					}
+				}
 			}
 		}
 
@@ -206,6 +228,61 @@ public class OrphanDetectionTestRule
 			Stack<Map<BaseModel<?>, String>> recordsStack) {
 
 			_recordsStack = recordsStack;
+		}
+
+		private void _checkResourceModelResourcePermissions(
+				BaseModel<?> baseModel, String backtraceInfo,
+				Map<String, PersistedModelLocalService>
+					persistedModelLocalServices)
+			throws PortalException {
+
+			PersistedModelLocalService persistedModelLocalService =
+				persistedModelLocalServices.get(baseModel.getModelClassName());
+
+			if (!(persistedModelLocalService instanceof
+					PersistedResourcedModelLocalService)) {
+
+				return;
+			}
+
+			ResourcedModel resourcedModel = (ResourcedModel)baseModel;
+
+			PersistedResourcedModelLocalService
+				persistedResourcedModelLocalService =
+					(PersistedResourcedModelLocalService)
+						persistedModelLocalService;
+
+			List<? extends PersistedModel> persistedResourcedModels =
+				persistedResourcedModelLocalService.getPersistedModel(
+					resourcedModel.getResourcePrimKey());
+
+			if (!persistedResourcedModels.isEmpty()) {
+				return;
+			}
+
+			ShardedModel shardedModel = (ShardedModel)baseModel;
+
+			int count =
+				ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
+					shardedModel.getCompanyId(), baseModel.getModelClassName(),
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourcedModel.getResourcePrimKey()));
+
+			Assert.assertEquals(
+				StringBundler.concat(
+					"Orphan ResourcePermission after the deletion of ",
+					baseModel.getModelClassName(), ": ", baseModel,
+					" with backtraceInfo ", backtraceInfo),
+				0, count);
+		}
+
+		private Map<String, PersistedModelLocalService>
+			_getPersistedModelLocalServices() {
+
+			return ReflectionTestUtil.getFieldValue(
+				PersistedModelLocalServiceRegistryUtil.
+					getPersistedModelLocalServiceRegistry(),
+				"_persistedModelLocalServices");
 		}
 
 		private Stack<Map<BaseModel<?>, String>> _recordsStack;

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/portal-test/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CompanyProviderClassTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuardTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRunMethodTestRule;
+import com.liferay.portal.kernel.test.rule.OrphanDetectionTestRule;
 import com.liferay.portal.kernel.test.rule.PortalRunModeClassTestRule;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.rule.TimeoutTestRule;
@@ -52,6 +53,7 @@ public class LiferayIntegrationTestRule extends AggregateTestRule {
 		testRules.add(UniqueStringRandomizerBumperClassTestRule.INSTANCE);
 		testRules.add(CompanyProviderClassTestRule.INSTANCE);
 		testRules.add(DeleteAfterTestRunMethodTestRule.INSTANCE);
+		testRules.add(OrphanDetectionTestRule.INSTANCE);
 		testRules.add(InjectTestRule.INSTANCE);
 		testRules.add(PortalRunModeClassTestRule.INSTANCE);
 


### PR DESCRIPTION
- LPS-1 New OrphanDetectionTestRule
- LPS-1 Semver
- LPS-2 Replace LocalServiceBaseImpl delete method calls with LocalServiceImpl ones in the tests
- LPS-2 Call the correct deleteCTCollection
- LPS-2 Avoid error when the AssetEntry record doesn't exist
