### PR TITLE
orphan_detection_3

### DIFF
--- a/modules/apps/announcements/announcements-uad/src/main/java/com/liferay/announcements/uad/anonymizer/BaseAnnouncementsEntryUADAnonymizer.java
+++ b/modules/apps/announcements/announcements-uad/src/main/java/com/liferay/announcements/uad/anonymizer/BaseAnnouncementsEntryUADAnonymizer.java
@@ -52,9 +52,10 @@ public abstract class BaseAnnouncementsEntryUADAnonymizer
 	}
 
 	@Override
-	public void delete(AnnouncementsEntry announcementsEntry) {
-		announcementsEntryLocalService.deleteAnnouncementsEntry(
-			announcementsEntry);
+	public void delete(AnnouncementsEntry announcementsEntry)
+		throws PortalException {
+
+		announcementsEntryLocalService.deleteEntry(announcementsEntry);
 	}
 
 	@Override

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanLocalServiceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanLocalServiceImpl.java
@@ -96,7 +96,7 @@ public class BatchPlannerPlanLocalServiceImpl
 			batchPlannerPlanId);
 
 		resourceLocalService.deleteResource(
-			batchPlannerPlan, ResourceConstants.SCOPE_COMPANY);
+			batchPlannerPlan, ResourceConstants.SCOPE_INDIVIDUAL);
 
 		BatchPlannerLog batchPlannerLog =
 			batchPlannerLogPersistence.fetchByBatchPlannerPlanId(

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/model/listener/GroupModelListener.java
@@ -47,7 +47,8 @@ public class GroupModelListener extends BaseModelListener<Group> {
 							group.getGroupId());
 
 					if (depotEntry != null) {
-						_depotEntryLocalService.deleteDepotEntry(depotEntry);
+						_depotEntryLocalService.deleteDepotEntry(
+							depotEntry.getDepotEntryId());
 					}
 
 					return null;

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
@@ -331,7 +331,11 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 			return false;
 		}
 
-		Group group = depotEntry.getGroup();
+		Group group = _groupLocalService.fetchGroup(depotEntry.getGroupId());
+
+		if (group == null) {
+			return false;
+		}
 
 		if (group.isStaged()) {
 			return true;

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderLocalServiceImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -130,6 +131,12 @@ public class KBFolderLocalServiceImpl extends KBFolderLocalServiceBaseImpl {
 		for (KBFolder childKBFolder : childKBFolders) {
 			deleteKBFolder(childKBFolder.getKbFolderId());
 		}
+
+		// Resources
+
+		resourceLocalService.deleteResource(
+			kbFolder.getCompanyId(), KBFolder.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, kbFolder.getKbFolderId());
 
 		// Expando
 

--- a/modules/apps/list-type/list-type-service/src/main/java/com/liferay/list/type/service/impl/ListTypeDefinitionLocalServiceImpl.java
+++ b/modules/apps/list-type/list-type-service/src/main/java/com/liferay/list/type/service/impl/ListTypeDefinitionLocalServiceImpl.java
@@ -95,6 +95,9 @@ public class ListTypeDefinitionLocalServiceImpl
 			throw new RequiredListTypeDefinitionException();
 		}
 
+		_resourceLocalService.deleteResource(
+			listTypeDefinition, ResourceConstants.SCOPE_INDIVIDUAL);
+
 		listTypeDefinition = listTypeDefinitionPersistence.remove(
 			listTypeDefinition);
 
@@ -114,12 +117,7 @@ public class ListTypeDefinitionLocalServiceImpl
 			listTypeDefinitionPersistence.findByPrimaryKey(
 				listTypeDefinitionId);
 
-		listTypeDefinition = deleteListTypeDefinition(listTypeDefinition);
-
-		_resourceLocalService.deleteResource(
-			listTypeDefinition, ResourceConstants.SCOPE_INDIVIDUAL);
-
-		return listTypeDefinition;
+		return deleteListTypeDefinition(listTypeDefinition);
 	}
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/microblogs/microblogs-service/src/main/java/com/liferay/microblogs/service/impl/MicroblogsEntryLocalServiceImpl.java
+++ b/modules/apps/microblogs/microblogs-service/src/main/java/com/liferay/microblogs/service/impl/MicroblogsEntryLocalServiceImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
@@ -246,6 +247,14 @@ public class MicroblogsEntryLocalServiceImpl
 
 			_assetEntryLocalService.deleteEntry(
 				MicroblogsEntry.class.getName(),
+				curMicroblogsEntry.getMicroblogsEntryId());
+
+			// Resource
+
+			resourceLocalService.deleteResource(
+				curMicroblogsEntry.getCompanyId(),
+				MicroblogsEntry.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
 				curMicroblogsEntry.getMicroblogsEntryId());
 
 			// Social

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupInstanceLocalService.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupInstanceLocalService.java
@@ -107,7 +107,8 @@ public interface MDRRuleGroupInstanceLocalService
 	public PersistedModel createPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
-	public void deleteGroupRuleGroupInstances(long groupId);
+	public void deleteGroupRuleGroupInstances(long groupId)
+		throws PortalException;
 
 	/**
 	 * Deletes the mdr rule group instance with the primary key from the database. Also notifies the appropriate model listeners.
@@ -146,15 +147,18 @@ public interface MDRRuleGroupInstanceLocalService
 	public PersistedModel deletePersistedModel(PersistedModel persistedModel)
 		throws PortalException;
 
-	public void deleteRuleGroupInstance(long ruleGroupInstanceId);
+	public void deleteRuleGroupInstance(long ruleGroupInstanceId)
+		throws PortalException;
 
 	@SystemEvent(
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public void deleteRuleGroupInstance(MDRRuleGroupInstance ruleGroupInstance);
+	public void deleteRuleGroupInstance(MDRRuleGroupInstance ruleGroupInstance)
+		throws PortalException;
 
-	public void deleteRuleGroupInstances(long ruleGroupId);
+	public void deleteRuleGroupInstances(long ruleGroupId)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupInstanceLocalServiceUtil.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupInstanceLocalServiceUtil.java
@@ -102,7 +102,9 @@ public class MDRRuleGroupInstanceLocalServiceUtil {
 		return getService().createPersistedModel(primaryKeyObj);
 	}
 
-	public static void deleteGroupRuleGroupInstances(long groupId) {
+	public static void deleteGroupRuleGroupInstances(long groupId)
+		throws PortalException {
+
 		getService().deleteGroupRuleGroupInstances(groupId);
 	}
 
@@ -150,17 +152,22 @@ public class MDRRuleGroupInstanceLocalServiceUtil {
 		return getService().deletePersistedModel(persistedModel);
 	}
 
-	public static void deleteRuleGroupInstance(long ruleGroupInstanceId) {
+	public static void deleteRuleGroupInstance(long ruleGroupInstanceId)
+		throws PortalException {
+
 		getService().deleteRuleGroupInstance(ruleGroupInstanceId);
 	}
 
 	public static void deleteRuleGroupInstance(
-		MDRRuleGroupInstance ruleGroupInstance) {
+			MDRRuleGroupInstance ruleGroupInstance)
+		throws PortalException {
 
 		getService().deleteRuleGroupInstance(ruleGroupInstance);
 	}
 
-	public static void deleteRuleGroupInstances(long ruleGroupId) {
+	public static void deleteRuleGroupInstances(long ruleGroupId)
+		throws PortalException {
+
 		getService().deleteRuleGroupInstances(ruleGroupId);
 	}
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupInstanceLocalServiceWrapper.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupInstanceLocalServiceWrapper.java
@@ -107,7 +107,9 @@ public class MDRRuleGroupInstanceLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteGroupRuleGroupInstances(long groupId) {
+	public void deleteGroupRuleGroupInstances(long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_mdrRuleGroupInstanceLocalService.deleteGroupRuleGroupInstances(
 			groupId);
 	}
@@ -165,22 +167,27 @@ public class MDRRuleGroupInstanceLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteRuleGroupInstance(long ruleGroupInstanceId) {
+	public void deleteRuleGroupInstance(long ruleGroupInstanceId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_mdrRuleGroupInstanceLocalService.deleteRuleGroupInstance(
 			ruleGroupInstanceId);
 	}
 
 	@Override
 	public void deleteRuleGroupInstance(
-		com.liferay.mobile.device.rules.model.MDRRuleGroupInstance
-			ruleGroupInstance) {
+			com.liferay.mobile.device.rules.model.MDRRuleGroupInstance
+				ruleGroupInstance)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_mdrRuleGroupInstanceLocalService.deleteRuleGroupInstance(
 			ruleGroupInstance);
 	}
 
 	@Override
-	public void deleteRuleGroupInstances(long ruleGroupId) {
+	public void deleteRuleGroupInstances(long ruleGroupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_mdrRuleGroupInstanceLocalService.deleteRuleGroupInstances(ruleGroupId);
 	}
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupLocalService.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupLocalService.java
@@ -147,15 +147,15 @@ public interface MDRRuleGroupLocalService
 	public PersistedModel deletePersistedModel(PersistedModel persistedModel)
 		throws PortalException;
 
-	public void deleteRuleGroup(long ruleGroupId);
+	public void deleteRuleGroup(long ruleGroupId) throws PortalException;
 
 	@SystemEvent(
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public void deleteRuleGroup(MDRRuleGroup ruleGroup);
+	public void deleteRuleGroup(MDRRuleGroup ruleGroup) throws PortalException;
 
-	public void deleteRuleGroups(long groupId);
+	public void deleteRuleGroups(long groupId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupLocalServiceUtil.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupLocalServiceUtil.java
@@ -149,15 +149,19 @@ public class MDRRuleGroupLocalServiceUtil {
 		return getService().deletePersistedModel(persistedModel);
 	}
 
-	public static void deleteRuleGroup(long ruleGroupId) {
+	public static void deleteRuleGroup(long ruleGroupId)
+		throws PortalException {
+
 		getService().deleteRuleGroup(ruleGroupId);
 	}
 
-	public static void deleteRuleGroup(MDRRuleGroup ruleGroup) {
+	public static void deleteRuleGroup(MDRRuleGroup ruleGroup)
+		throws PortalException {
+
 		getService().deleteRuleGroup(ruleGroup);
 	}
 
-	public static void deleteRuleGroups(long groupId) {
+	public static void deleteRuleGroups(long groupId) throws PortalException {
 		getService().deleteRuleGroups(groupId);
 	}
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupLocalServiceWrapper.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupLocalServiceWrapper.java
@@ -159,19 +159,24 @@ public class MDRRuleGroupLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteRuleGroup(long ruleGroupId) {
+	public void deleteRuleGroup(long ruleGroupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_mdrRuleGroupLocalService.deleteRuleGroup(ruleGroupId);
 	}
 
 	@Override
 	public void deleteRuleGroup(
-		com.liferay.mobile.device.rules.model.MDRRuleGroup ruleGroup) {
+			com.liferay.mobile.device.rules.model.MDRRuleGroup ruleGroup)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_mdrRuleGroupLocalService.deleteRuleGroup(ruleGroup);
 	}
 
 	@Override
-	public void deleteRuleGroups(long groupId) {
+	public void deleteRuleGroups(long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_mdrRuleGroupLocalService.deleteRuleGroups(groupId);
 	}
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupInstanceLocalServiceImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupInstanceLocalServiceImpl.java
@@ -24,6 +24,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -110,7 +111,9 @@ public class MDRRuleGroupInstanceLocalServiceImpl
 	}
 
 	@Override
-	public void deleteGroupRuleGroupInstances(long groupId) {
+	public void deleteGroupRuleGroupInstances(long groupId)
+		throws PortalException {
+
 		List<MDRRuleGroupInstance> ruleGroupInstances =
 			mdrRuleGroupInstancePersistence.findByGroupId(groupId);
 
@@ -121,7 +124,9 @@ public class MDRRuleGroupInstanceLocalServiceImpl
 	}
 
 	@Override
-	public void deleteRuleGroupInstance(long ruleGroupInstanceId) {
+	public void deleteRuleGroupInstance(long ruleGroupInstanceId)
+		throws PortalException {
+
 		MDRRuleGroupInstance ruleGroupInstance =
 			mdrRuleGroupInstancePersistence.fetchByPrimaryKey(
 				ruleGroupInstanceId);
@@ -135,8 +140,13 @@ public class MDRRuleGroupInstanceLocalServiceImpl
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public void deleteRuleGroupInstance(
-		MDRRuleGroupInstance ruleGroupInstance) {
+	public void deleteRuleGroupInstance(MDRRuleGroupInstance ruleGroupInstance)
+		throws PortalException {
+
+		// Resource
+
+		_resourceLocalService.deleteResource(
+			ruleGroupInstance, ResourceConstants.SCOPE_INDIVIDUAL);
 
 		// Rule group instance
 
@@ -169,7 +179,9 @@ public class MDRRuleGroupInstanceLocalServiceImpl
 	}
 
 	@Override
-	public void deleteRuleGroupInstances(long ruleGroupId) {
+	public void deleteRuleGroupInstances(long ruleGroupId)
+		throws PortalException {
+
 		List<MDRRuleGroupInstance> ruleGroupInstances =
 			mdrRuleGroupInstancePersistence.findByRuleGroupId(ruleGroupId);
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupLocalServiceImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ResourceLocalService;
@@ -129,7 +130,7 @@ public class MDRRuleGroupLocalServiceImpl
 	}
 
 	@Override
-	public void deleteRuleGroup(long ruleGroupId) {
+	public void deleteRuleGroup(long ruleGroupId) throws PortalException {
 		MDRRuleGroup ruleGroup = mdrRuleGroupPersistence.fetchByPrimaryKey(
 			ruleGroupId);
 
@@ -143,7 +144,12 @@ public class MDRRuleGroupLocalServiceImpl
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public void deleteRuleGroup(MDRRuleGroup ruleGroup) {
+	public void deleteRuleGroup(MDRRuleGroup ruleGroup) throws PortalException {
+
+		// Resource
+
+		_resourceLocalService.deleteResource(
+			ruleGroup, ResourceConstants.SCOPE_INDIVIDUAL);
 
 		// Rule group
 
@@ -160,7 +166,7 @@ public class MDRRuleGroupLocalServiceImpl
 	}
 
 	@Override
-	public void deleteRuleGroups(long groupId) {
+	public void deleteRuleGroups(long groupId) throws PortalException {
 		List<MDRRuleGroup> ruleGroups = mdrRuleGroupPersistence.findByGroupId(
 			groupId);
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/exportimport/data/handler/MDRRuleGroupInstanceStagedModelDataHandler.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/exportimport/data/handler/MDRRuleGroupInstanceStagedModelDataHandler.java
@@ -25,6 +25,7 @@ import com.liferay.mobile.device.rules.model.MDRRuleGroupInstance;
 import com.liferay.mobile.device.rules.service.MDRRuleGroupInstanceLocalService;
 import com.liferay.mobile.device.rules.service.MDRRuleGroupLocalService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -52,14 +53,17 @@ public class MDRRuleGroupInstanceStagedModelDataHandler
 	};
 
 	@Override
-	public void deleteStagedModel(MDRRuleGroupInstance ruleGroupInstance) {
+	public void deleteStagedModel(MDRRuleGroupInstance ruleGroupInstance)
+		throws PortalException {
+
 		_mdrRuleGroupInstanceLocalService.deleteRuleGroupInstance(
 			ruleGroupInstance);
 	}
 
 	@Override
 	public void deleteStagedModel(
-		String uuid, long groupId, String className, String extraData) {
+			String uuid, long groupId, String className, String extraData)
+		throws PortalException {
 
 		MDRRuleGroupInstance ruleGroupInstance =
 			fetchStagedModelByUuidAndGroupId(uuid, groupId);

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/exportimport/data/handler/MDRRuleGroupStagedModelDataHandler.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/exportimport/data/handler/MDRRuleGroupStagedModelDataHandler.java
@@ -22,6 +22,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
 import com.liferay.mobile.device.rules.model.MDRRuleGroup;
 import com.liferay.mobile.device.rules.service.MDRRuleGroupLocalService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.xml.Element;
 
@@ -41,13 +42,16 @@ public class MDRRuleGroupStagedModelDataHandler
 	public static final String[] CLASS_NAMES = {MDRRuleGroup.class.getName()};
 
 	@Override
-	public void deleteStagedModel(MDRRuleGroup ruleGroup) {
+	public void deleteStagedModel(MDRRuleGroup ruleGroup)
+		throws PortalException {
+
 		_mdrRuleGroupLocalService.deleteRuleGroup(ruleGroup);
 	}
 
 	@Override
 	public void deleteStagedModel(
-		String uuid, long groupId, String className, String extraData) {
+			String uuid, long groupId, String className, String extraData)
+		throws PortalException {
 
 		MDRRuleGroup ruleGroup = fetchStagedModelByUuidAndGroupId(
 			uuid, groupId);

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -49,6 +49,7 @@ import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.RepositoryFactory;
@@ -374,6 +375,12 @@ public class OAuth2ApplicationLocalServiceImpl
 					oAuth2ApplicationScopeAliases.
 						getOAuth2ApplicationScopeAliasesId());
 		}
+
+		OAuth2Application oAuth2Application = fetchOAuth2Application(
+			oAuth2ApplicationId);
+
+		_resourceLocalService.deleteResource(
+			oAuth2Application, ResourceConstants.SCOPE_INDIVIDUAL);
 
 		return oAuth2ApplicationPersistence.remove(oAuth2ApplicationId);
 	}

--- a/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/exportimport/staged/model/repository/TemplateEntryStagedModelRepository.java
+++ b/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/exportimport/staged/model/repository/TemplateEntryStagedModelRepository.java
@@ -90,7 +90,7 @@ public class TemplateEntryStagedModelRepository
 	public void deleteStagedModel(TemplateEntry templateEntry)
 		throws PortalException {
 
-		_ddmTemplateLocalService.deleteDDMTemplate(
+		_ddmTemplateLocalService.deleteTemplate(
 			templateEntry.getDDMTemplateId());
 
 		_templateEntryLocalService.deleteTemplateEntry(templateEntry);

--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/portlet/action/DeleteTemplateEntryMVCActionCommand.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/portlet/action/DeleteTemplateEntryMVCActionCommand.java
@@ -64,7 +64,7 @@ public class DeleteTemplateEntryMVCActionCommand
 				_templateEntryLocalService.deleteTemplateEntry(
 					deleteTemplateEntryId);
 
-			_ddmTemplateLocalService.deleteDDMTemplate(
+			_ddmTemplateLocalService.deleteTemplate(
 				templateEntry.getDDMTemplateId());
 		}
 	}

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/messaging/KaleoDefinitionVersionModelListener.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/messaging/KaleoDefinitionVersionModelListener.java
@@ -53,7 +53,7 @@ public class KaleoDefinitionVersionModelListener
 
 		try {
 			_resourceLocalService.deleteResource(
-				kaleoDefinitionVersion, ResourceConstants.SCOPE_COMPANY);
+				kaleoDefinitionVersion, ResourceConstants.SCOPE_INDIVIDUAL);
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);

--- a/portal-impl/src/com/liferay/portal/service/base/RepositoryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/RepositoryLocalServiceBaseImpl.java
@@ -138,10 +138,13 @@ public abstract class RepositoryLocalServiceBaseImpl
 	 *
 	 * @param repository the repository
 	 * @return the repository that was removed
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	@Override
-	public Repository deleteRepository(Repository repository) {
+	public Repository deleteRepository(Repository repository)
+		throws PortalException {
+
 		return repositoryPersistence.remove(repository);
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1658,8 +1658,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			_actionableDynamicQuery.setCompanyId(companyId);
 			_actionableDynamicQuery.setPerformActionMethod(
 				(ExpandoColumn expandoColumn) ->
-					_expandoColumnLocalService.deleteExpandoColumn(
-						expandoColumn));
+					_expandoColumnLocalService.deleteColumn(expandoColumn));
 		}
 
 		protected void performActions() throws PortalException {

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.model.LayoutBranchConstants;
 import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.model.LayoutRevisionConstants;
 import com.liferay.portal.kernel.model.LayoutSetBranch;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.RecentLayoutBranchLocalService;
@@ -135,6 +136,11 @@ public class LayoutBranchLocalServiceImpl
 			layoutBranch.getPlid());
 
 		_recentLayoutBranchLocalService.deleteRecentLayoutBranches(
+			layoutBranch.getLayoutBranchId());
+
+		_resourceLocalService.deleteResource(
+			layoutBranch.getCompanyId(), LayoutBranch.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
 			layoutBranch.getLayoutBranchId());
 
 		return deleteLayoutBranch(layoutBranch);

--- a/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
@@ -169,7 +169,9 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public Repository deleteRepository(Repository repository) {
+	public Repository deleteRepository(Repository repository)
+		throws PortalException {
+
 		_expandoValueLocalService.deleteValues(
 			Repository.class.getName(), repository.getRepositoryId());
 
@@ -177,7 +179,7 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 			repository.getDlFolderId());
 
 		if (dlFolder != null) {
-			_dlFolderLocalService.deleteDLFolder(dlFolder);
+			_dlFolderLocalService.deleteFolder(dlFolder);
 		}
 
 		repositoryPersistence.remove(repository);

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -461,14 +461,9 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 				resourcePermission);
 		}
 
-		String className = role.getClassName();
-		long classNameId = role.getClassNameId();
-
-		if ((classNameId <= 0) || className.equals(Role.class.getName())) {
-			_resourceLocalService.deleteResource(
-				role.getCompanyId(), Role.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL, role.getRoleId());
-		}
+		_resourceLocalService.deleteResource(
+			role.getCompanyId(), Role.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, role.getRoleId());
 
 		if ((role.getType() == RoleConstants.TYPE_DEPOT) ||
 			(role.getType() == RoleConstants.TYPE_ORGANIZATION) ||

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
@@ -272,7 +272,7 @@ public class DLFileShortcutLocalServiceImpl
 
 		actionableDynamicQuery.setPerformActionMethod(
 			(DLFileShortcut fileShortcut) ->
-				dlFileShortcutLocalService.deleteDLFileShortcut(fileShortcut));
+				dlFileShortcutLocalService.deleteFileShortcut(fileShortcut));
 
 		actionableDynamicQuery.performActions();
 	}

--- a/portal-impl/src/com/liferay/portlet/expando/service/base/ExpandoTableLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/base/ExpandoTableLocalServiceBaseImpl.java
@@ -138,10 +138,13 @@ public abstract class ExpandoTableLocalServiceBaseImpl
 	 *
 	 * @param expandoTable the expando table
 	 * @return the expando table that was removed
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	@Override
-	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable) {
+	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable)
+		throws PortalException {
+
 		return expandoTablePersistence.remove(expandoTable);
 	}
 

--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoColumnLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoColumnLocalServiceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.adapter.ModelAdapterUtil;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
@@ -92,7 +93,7 @@ public class ExpandoColumnLocalServiceImpl
 	}
 
 	@Override
-	public void deleteColumn(ExpandoColumn column) {
+	public void deleteColumn(ExpandoColumn column) throws PortalException {
 		addDeletionSystemEvent(column);
 
 		// Column
@@ -102,6 +103,12 @@ public class ExpandoColumnLocalServiceImpl
 		// Values
 
 		expandoValueLocalService.deleteColumnValues(column.getColumnId());
+
+		// Resources
+
+		resourceLocalService.deleteResource(
+			column.getCompanyId(), ExpandoColumn.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, column.getColumnId());
 	}
 
 	@Override
@@ -124,7 +131,7 @@ public class ExpandoColumnLocalServiceImpl
 	}
 
 	@Override
-	public void deleteColumn(long tableId, String name) {
+	public void deleteColumn(long tableId, String name) throws PortalException {
 		ExpandoColumn column = expandoColumnPersistence.fetchByT_N(
 			tableId, name);
 
@@ -144,7 +151,7 @@ public class ExpandoColumnLocalServiceImpl
 	}
 
 	@Override
-	public void deleteColumns(long tableId) {
+	public void deleteColumns(long tableId) throws PortalException {
 		List<ExpandoColumn> columns = expandoColumnPersistence.findByTableId(
 			tableId);
 

--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoTableLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoTableLocalServiceImpl.java
@@ -80,30 +80,32 @@ public class ExpandoTableLocalServiceImpl
 	}
 
 	@Override
-	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable) {
+	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable)
+		throws PortalException {
+
 		deleteTable(expandoTable);
 
 		return expandoTable;
 	}
 
 	@Override
-	public void deleteTable(ExpandoTable table) {
+	public void deleteTable(ExpandoTable table) throws PortalException {
 
-		// Table
+		// Values
 
-		expandoTablePersistence.remove(table);
-
-		// Columns
-
-		expandoColumnPersistence.removeByTableId(table.getTableId());
+		expandoValuePersistence.removeByTableId(table.getTableId());
 
 		// Rows
 
 		expandoRowPersistence.removeByTableId(table.getTableId());
 
-		// Values
+		// Columns
 
-		expandoValuePersistence.removeByTableId(table.getTableId());
+		expandoColumnLocalService.deleteColumns(table.getTableId());
+
+		// Table
+
+		expandoTablePersistence.remove(table);
 	}
 
 	@Override
@@ -132,7 +134,9 @@ public class ExpandoTableLocalServiceImpl
 	}
 
 	@Override
-	public void deleteTables(long companyId, long classNameId) {
+	public void deleteTables(long companyId, long classNameId)
+		throws PortalException {
+
 		List<ExpandoTable> tables = expandoTablePersistence.findByC_C(
 			companyId, classNameId);
 
@@ -142,7 +146,9 @@ public class ExpandoTableLocalServiceImpl
 	}
 
 	@Override
-	public void deleteTables(long companyId, String className) {
+	public void deleteTables(long companyId, String className)
+		throws PortalException {
+
 		deleteTables(
 			companyId, classNameLocalService.getClassNameId(className));
 	}

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoColumnLocalService.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoColumnLocalService.java
@@ -103,7 +103,7 @@ public interface ExpandoColumnLocalService
 	public PersistedModel createPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
-	public void deleteColumn(ExpandoColumn column);
+	public void deleteColumn(ExpandoColumn column) throws PortalException;
 
 	public void deleteColumn(long columnId) throws PortalException;
 
@@ -111,13 +111,13 @@ public interface ExpandoColumnLocalService
 			long companyId, long classNameId, String tableName, String name)
 		throws PortalException;
 
-	public void deleteColumn(long tableId, String name);
+	public void deleteColumn(long tableId, String name) throws PortalException;
 
 	public void deleteColumn(
 			long companyId, String className, String tableName, String name)
 		throws PortalException;
 
-	public void deleteColumns(long tableId);
+	public void deleteColumns(long tableId) throws PortalException;
 
 	public void deleteColumns(
 			long companyId, long classNameId, String tableName)

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoColumnLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoColumnLocalServiceUtil.java
@@ -91,7 +91,9 @@ public class ExpandoColumnLocalServiceUtil {
 		return getService().createPersistedModel(primaryKeyObj);
 	}
 
-	public static void deleteColumn(ExpandoColumn column) {
+	public static void deleteColumn(ExpandoColumn column)
+		throws PortalException {
+
 		getService().deleteColumn(column);
 	}
 
@@ -106,7 +108,9 @@ public class ExpandoColumnLocalServiceUtil {
 		getService().deleteColumn(companyId, classNameId, tableName, name);
 	}
 
-	public static void deleteColumn(long tableId, String name) {
+	public static void deleteColumn(long tableId, String name)
+		throws PortalException {
+
 		getService().deleteColumn(tableId, name);
 	}
 
@@ -117,7 +121,7 @@ public class ExpandoColumnLocalServiceUtil {
 		getService().deleteColumn(companyId, className, tableName, name);
 	}
 
-	public static void deleteColumns(long tableId) {
+	public static void deleteColumns(long tableId) throws PortalException {
 		getService().deleteColumns(tableId);
 	}
 

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoColumnLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoColumnLocalServiceWrapper.java
@@ -94,7 +94,9 @@ public class ExpandoColumnLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteColumn(ExpandoColumn column) {
+	public void deleteColumn(ExpandoColumn column)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_expandoColumnLocalService.deleteColumn(column);
 	}
 
@@ -115,7 +117,9 @@ public class ExpandoColumnLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteColumn(long tableId, String name) {
+	public void deleteColumn(long tableId, String name)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_expandoColumnLocalService.deleteColumn(tableId, name);
 	}
 
@@ -129,7 +133,9 @@ public class ExpandoColumnLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteColumns(long tableId) {
+	public void deleteColumns(long tableId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_expandoColumnLocalService.deleteColumns(tableId);
 	}
 

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoTableLocalService.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoTableLocalService.java
@@ -116,9 +116,11 @@ public interface ExpandoTableLocalService
 	 *
 	 * @param expandoTable the expando table
 	 * @return the expando table that was removed
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
-	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable);
+	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable)
+		throws PortalException;
 
 	/**
 	 * Deletes the expando table with the primary key from the database. Also notifies the appropriate model listeners.
@@ -141,7 +143,7 @@ public interface ExpandoTableLocalService
 	public PersistedModel deletePersistedModel(PersistedModel persistedModel)
 		throws PortalException;
 
-	public void deleteTable(ExpandoTable table);
+	public void deleteTable(ExpandoTable table) throws PortalException;
 
 	public void deleteTable(long tableId) throws PortalException;
 
@@ -151,9 +153,11 @@ public interface ExpandoTableLocalService
 	public void deleteTable(long companyId, String className, String name)
 		throws PortalException;
 
-	public void deleteTables(long companyId, long classNameId);
+	public void deleteTables(long companyId, long classNameId)
+		throws PortalException;
 
-	public void deleteTables(long companyId, String className);
+	public void deleteTables(long companyId, String className)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoTableLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoTableLocalServiceUtil.java
@@ -113,8 +113,11 @@ public class ExpandoTableLocalServiceUtil {
 	 *
 	 * @param expandoTable the expando table
 	 * @return the expando table that was removed
+	 * @throws PortalException
 	 */
-	public static ExpandoTable deleteExpandoTable(ExpandoTable expandoTable) {
+	public static ExpandoTable deleteExpandoTable(ExpandoTable expandoTable)
+		throws PortalException {
+
 		return getService().deleteExpandoTable(expandoTable);
 	}
 
@@ -145,7 +148,7 @@ public class ExpandoTableLocalServiceUtil {
 		return getService().deletePersistedModel(persistedModel);
 	}
 
-	public static void deleteTable(ExpandoTable table) {
+	public static void deleteTable(ExpandoTable table) throws PortalException {
 		getService().deleteTable(table);
 	}
 
@@ -167,11 +170,15 @@ public class ExpandoTableLocalServiceUtil {
 		getService().deleteTable(companyId, className, name);
 	}
 
-	public static void deleteTables(long companyId, long classNameId) {
+	public static void deleteTables(long companyId, long classNameId)
+		throws PortalException {
+
 		getService().deleteTables(companyId, classNameId);
 	}
 
-	public static void deleteTables(long companyId, String className) {
+	public static void deleteTables(long companyId, String className)
+		throws PortalException {
+
 		getService().deleteTables(companyId, className);
 	}
 

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoTableLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoTableLocalServiceWrapper.java
@@ -115,9 +115,12 @@ public class ExpandoTableLocalServiceWrapper
 	 *
 	 * @param expandoTable the expando table
 	 * @return the expando table that was removed
+	 * @throws PortalException
 	 */
 	@Override
-	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable) {
+	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		return _expandoTableLocalService.deleteExpandoTable(expandoTable);
 	}
 
@@ -151,7 +154,9 @@ public class ExpandoTableLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteTable(ExpandoTable table) {
+	public void deleteTable(ExpandoTable table)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_expandoTableLocalService.deleteTable(table);
 	}
 
@@ -177,12 +182,16 @@ public class ExpandoTableLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteTables(long companyId, long classNameId) {
+	public void deleteTables(long companyId, long classNameId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_expandoTableLocalService.deleteTables(companyId, classNameId);
 	}
 
 	@Override
-	public void deleteTables(long companyId, String className) {
+	public void deleteTables(long companyId, String className)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_expandoTableLocalService.deleteTables(companyId, className);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalService.java
@@ -134,13 +134,15 @@ public interface RepositoryLocalService
 	 *
 	 * @param repository the repository
 	 * @return the repository that was removed
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	@SystemEvent(
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public Repository deleteRepository(Repository repository);
+	public Repository deleteRepository(Repository repository)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceUtil.java
@@ -135,8 +135,11 @@ public class RepositoryLocalServiceUtil {
 	 *
 	 * @param repository the repository
 	 * @return the repository that was removed
+	 * @throws PortalException
 	 */
-	public static Repository deleteRepository(Repository repository) {
+	public static Repository deleteRepository(Repository repository)
+		throws PortalException {
+
 		return getService().deleteRepository(repository);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceWrapper.java
@@ -141,10 +141,12 @@ public class RepositoryLocalServiceWrapper
 	 *
 	 * @param repository the repository
 	 * @return the repository that was removed
+	 * @throws PortalException
 	 */
 	@Override
 	public com.liferay.portal.kernel.model.Repository deleteRepository(
-		com.liferay.portal.kernel.model.Repository repository) {
+			com.liferay.portal.kernel.model.Repository repository)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _repositoryLocalService.deleteRepository(repository);
 	}


### PR DESCRIPTION
- LPS-100 Replace LocalServiceBaseImpl delete method calls with LocalServiceImpl ones
- LPS-100 Replace LocalServiceBaseImpl delete method calls with LocalServiceImpl ones
- LPS-103 Delete the Resource table entry when deleting an ExpandoColumn or an ExpandoTable
- LPS-112 Delete the resource of the KBFolder
- LPS-122 Delete the resource of the RedirectEntry record
- LPS-123 Delete the resource of the MicroblogsEntry
- LPS-129 Delete the resource of the KaleoDefinitionVersion entry
- LPS-132 Delete the resource of the OAuth2Application entry
- LPS-198 Call the correct delete method
- LPS-200 Delete ResourcePermission of MDRRuleGroup
- LPS-201 Call the correct SiteNavigationMenu deletion method
- LPS-202 Replace announcementsEntryLocalService.deleteAnnouncementsEntry with announcementsEntryLocalService.deleteEntry
- LPS-203 Delete in the correct scope SCOPE_COMPANY => SCOPE_INDIVIDUAL
- LPS-204 Replace deleteDDMTemplate with deleteTemplate methods
- LPS-205 Add resourceLocalService.deleteResource call
- LPS-206 Delete depot using the deleteDepotEntry(<id>) method in the tests
- LPS-207 Avoid error when it is called from the listener if the group doesn't exist
- LPS-208 Delete the resource permission of ListTypeDefinition
- LPS-209 Delete the resource permission of Role
