### PR TITLE
LPS-145396

### DIFF
--- a/modules/apps/announcements/announcements-uad/src/main/java/com/liferay/announcements/uad/anonymizer/BaseAnnouncementsEntryUADAnonymizer.java
+++ b/modules/apps/announcements/announcements-uad/src/main/java/com/liferay/announcements/uad/anonymizer/BaseAnnouncementsEntryUADAnonymizer.java
@@ -52,9 +52,10 @@ public abstract class BaseAnnouncementsEntryUADAnonymizer
 	}
 
 	@Override
-	public void delete(AnnouncementsEntry announcementsEntry) {
-		announcementsEntryLocalService.deleteAnnouncementsEntry(
-			announcementsEntry);
+	public void delete(AnnouncementsEntry announcementsEntry)
+		throws PortalException {
+
+		announcementsEntryLocalService.deleteEntry(announcementsEntry);
 	}
 
 	@Override

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/exportimport/test/AssetPublisherExportImportTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/exportimport/test/AssetPublisherExportImportTest.java
@@ -1208,7 +1208,7 @@ public class AssetPublisherExportImportTest
 				" does not belong to group ", expectedGroupId),
 			expectedGroupId, importedVocabulary.getGroupId());
 
-		_assetVocabularyLocalService.deleteAssetVocabulary(assetVocabulary);
+		_assetVocabularyLocalService.deleteVocabulary(assetVocabulary);
 	}
 
 	private static Configuration _assetPublisherWebConfiguration;

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/internal/exportimport/portlet/preferences/processor/test/AssetPublisherExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/internal/exportimport/portlet/preferences/processor/test/AssetPublisherExportImportPortletPreferencesProcessorTest.java
@@ -123,7 +123,7 @@ public class AssetPublisherExportImportPortletPreferencesProcessorTest {
 		// Update asset vocabulary to have a different primary key. We will swap
 		// to the new one and verify it.
 
-		AssetVocabularyLocalServiceUtil.deleteAssetVocabulary(
+		AssetVocabularyLocalServiceUtil.deleteVocabulary(
 			assetVocabulary.getVocabularyId());
 
 		assetVocabulary = AssetTestUtil.addVocabulary(_group.getGroupId());
@@ -178,7 +178,7 @@ public class AssetPublisherExportImportPortletPreferencesProcessorTest {
 		// Update asset vocabulary to have a different primary key. We will swap
 		// to the new one and verify it.
 
-		AssetCategoryLocalServiceUtil.deleteAssetCategory(
+		AssetCategoryLocalServiceUtil.deleteCategory(
 			assetCategory.getCategoryId());
 
 		assetCategory = AssetTestUtil.addCategory(

--- a/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanLocalServiceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-service/src/main/java/com/liferay/batch/planner/service/impl/BatchPlannerPlanLocalServiceImpl.java
@@ -96,7 +96,7 @@ public class BatchPlannerPlanLocalServiceImpl
 			batchPlannerPlanId);
 
 		resourceLocalService.deleteResource(
-			batchPlannerPlan, ResourceConstants.SCOPE_COMPANY);
+			batchPlannerPlan, ResourceConstants.SCOPE_INDIVIDUAL);
 
 		BatchPlannerLog batchPlannerLog =
 			batchPlannerLogPersistence.fetchByBatchPlannerPlanId(

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/closure/test/CTClosureFactoryImplTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/closure/test/CTClosureFactoryImplTest.java
@@ -194,8 +194,7 @@ public class CTClosureFactoryImplTest {
 					"CTCollectionLocalServiceImpl",
 				LoggerTestUtil.WARN)) {
 
-			_ctCollectionLocalService.deleteCTCollection(
-				_ctCollection.getCtCollectionId());
+			_ctCollectionLocalService.deleteCTCollection(_ctCollection);
 		}
 
 		_db.runSQL("drop table GrandParentTable");

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/test/CPDisplayLayoutLocalServiceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/test/CPDisplayLayoutLocalServiceTest.java
@@ -157,7 +157,7 @@ public class CPDisplayLayoutLocalServiceTest {
 
 		Assert.assertEquals(
 			2, _cpDisplayLayoutLocalService.getCPDisplayLayoutsCount());
-		AssetCategoryLocalServiceUtil.deleteAssetCategory(assetCategory);
+		AssetCategoryLocalServiceUtil.deleteCategory(assetCategory);
 		Assert.assertEquals(
 			0, _cpDisplayLayoutLocalService.getCPDisplayLayoutsCount());
 	}

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/util/test/CPDefinitionHelperTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/util/test/CPDefinitionHelperTest.java
@@ -213,7 +213,7 @@ public class CPDefinitionHelperTest {
 		Assert.assertTrue(
 			actualCPDefinitionIds.containsAll(cpDefinitionIdsList));
 
-		AssetCategoryLocalServiceUtil.deleteAssetCategory(
+		AssetCategoryLocalServiceUtil.deleteCategory(
 			assetCategory.getCategoryId());
 	}
 

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletGetPropsTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletGetPropsTest.java
@@ -166,7 +166,7 @@ public class ContentDashboardAdminPortletGetPropsTest {
 				String.valueOf(props.get("vocabularies")));
 		}
 		finally {
-			_assetVocabularyLocalService.deleteAssetVocabulary(assetVocabulary);
+			_assetVocabularyLocalService.deleteVocabulary(assetVocabulary);
 		}
 	}
 
@@ -483,9 +483,8 @@ public class ContentDashboardAdminPortletGetPropsTest {
 				String.valueOf(props.get("vocabularies")));
 		}
 		finally {
-			_assetVocabularyLocalService.deleteAssetVocabulary(assetVocabulary);
-			_assetVocabularyLocalService.deleteAssetVocabulary(
-				childAssetVocabulary);
+			_assetVocabularyLocalService.deleteVocabulary(assetVocabulary);
+			_assetVocabularyLocalService.deleteVocabulary(childAssetVocabulary);
 		}
 	}
 
@@ -592,9 +591,8 @@ public class ContentDashboardAdminPortletGetPropsTest {
 				String.valueOf(props.get("vocabularies")));
 		}
 		finally {
-			_assetVocabularyLocalService.deleteAssetVocabulary(assetVocabulary);
-			_assetVocabularyLocalService.deleteAssetVocabulary(
-				childAssetVocabulary);
+			_assetVocabularyLocalService.deleteVocabulary(assetVocabulary);
+			_assetVocabularyLocalService.deleteVocabulary(childAssetVocabulary);
 		}
 	}
 

--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletTest.java
@@ -182,8 +182,8 @@ public class ContentDashboardAdminPortletTest {
 						audienceAssetVocabulary, childAssetVocabulary)));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(assetCategory);
-			_assetCategoryLocalService.deleteAssetCategory(childAssetCategory);
+			_assetCategoryLocalService.deleteCategory(assetCategory);
+			_assetCategoryLocalService.deleteCategory(childAssetCategory);
 		}
 	}
 
@@ -230,7 +230,7 @@ public class ContentDashboardAdminPortletTest {
 				_getAuditGraphTitle(_getMockLiferayPortletRenderRequest()));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(assetCategory);
+			_assetCategoryLocalService.deleteCategory(assetCategory);
 		}
 	}
 
@@ -367,7 +367,7 @@ public class ContentDashboardAdminPortletTest {
 					LocaleUtil.US));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory.getCategoryId());
 		}
 	}
@@ -699,7 +699,7 @@ public class ContentDashboardAdminPortletTest {
 					LocaleUtil.US));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory.getCategoryId());
 		}
 	}
@@ -794,9 +794,9 @@ public class ContentDashboardAdminPortletTest {
 					LocaleUtil.US));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory1.getCategoryId());
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory2.getCategoryId());
 		}
 	}
@@ -1030,9 +1030,9 @@ public class ContentDashboardAdminPortletTest {
 					LocaleUtil.US));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory1.getCategoryId());
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory2.getCategoryId());
 		}
 	}
@@ -1321,7 +1321,7 @@ public class ContentDashboardAdminPortletTest {
 			Assert.assertEquals(assetCategory, assetCategories.get(0));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(
+			_assetCategoryLocalService.deleteCategory(
 				assetCategory.getCategoryId());
 		}
 	}
@@ -1461,8 +1461,8 @@ public class ContentDashboardAdminPortletTest {
 					String.valueOf(childAssetVocabulary.getVocabularyId())));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(assetCategory);
-			_assetCategoryLocalService.deleteAssetCategory(childAssetCategory);
+			_assetCategoryLocalService.deleteCategory(assetCategory);
+			_assetCategoryLocalService.deleteCategory(childAssetCategory);
 		}
 	}
 
@@ -1501,7 +1501,7 @@ public class ContentDashboardAdminPortletTest {
 					String.valueOf(stageAssetVocabulary.getVocabularyId())));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(assetCategory);
+			_assetCategoryLocalService.deleteCategory(assetCategory);
 		}
 	}
 
@@ -1548,8 +1548,8 @@ public class ContentDashboardAdminPortletTest {
 					String.valueOf(assetVocabulary.getVocabularyId())));
 		}
 		finally {
-			_assetCategoryLocalService.deleteAssetCategory(assetCategory);
-			_assetCategoryLocalService.deleteAssetCategory(childAssetCategory);
+			_assetCategoryLocalService.deleteCategory(assetCategory);
+			_assetCategoryLocalService.deleteCategory(childAssetCategory);
 		}
 	}
 

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/model/listener/GroupModelListener.java
@@ -47,7 +47,8 @@ public class GroupModelListener extends BaseModelListener<Group> {
 							group.getGroupId());
 
 					if (depotEntry != null) {
-						_depotEntryLocalService.deleteDepotEntry(depotEntry);
+						_depotEntryLocalService.deleteDepotEntry(
+							depotEntry.getDepotEntryId());
 					}
 
 					return null;

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/service/impl/DepotEntryLocalServiceImpl.java
@@ -331,7 +331,11 @@ public class DepotEntryLocalServiceImpl extends DepotEntryLocalServiceBaseImpl {
 			return false;
 		}
 
-		Group group = depotEntry.getGroup();
+		Group group = _groupLocalService.fetchGroup(depotEntry.getGroupId());
+
+		if (group == null) {
+			return false;
+		}
 
 		if (group.isStaged()) {
 			return true;

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/service/test/DepotEntryLocalServiceTest.java
@@ -146,7 +146,7 @@ public class DepotEntryLocalServiceTest {
 	public void testDeleteDepotEntry() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry("name", "description");
 
-		_depotEntryLocalService.deleteDepotEntry(depotEntry);
+		_depotEntryLocalService.deleteDepotEntry(depotEntry.getDepotEntryId());
 
 		_depotEntries.remove(depotEntry);
 

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryMetadataDDMStructureFixture.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntryMetadataDDMStructureFixture.java
@@ -145,7 +145,7 @@ public class DLFileEntryMetadataDDMStructureFixture {
 
 	protected void deleteAllFileEntryTypes() throws PortalException {
 		for (DLFileEntryType dlFileEntryType : _fileEntryTypes) {
-			_dlFileEntryTypeLocalService.deleteDLFileEntryType(dlFileEntryType);
+			_dlFileEntryTypeLocalService.deleteFileEntryType(dlFileEntryType);
 		}
 
 		_fileEntryTypes.clear();

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/search/test/DLFileEntrySearchTest.java
@@ -409,7 +409,7 @@ public class DLFileEntrySearchTest extends BaseSearchTestCase {
 
 	@Override
 	protected void deleteBaseModel(long primaryKey) throws Exception {
-		DLFileEntryLocalServiceUtil.deleteDLFileEntry(primaryKey);
+		DLFileEntryLocalServiceUtil.deleteFileEntry(primaryKey);
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileEntryTypeServiceTest.java
@@ -206,7 +206,7 @@ public class DLFileEntryTypeServiceTest {
 
 		Assert.assertTrue(hasUserLocale);
 
-		DLFileEntryTypeLocalServiceUtil.deleteDLFileEntryType(dlFileEntryType);
+		DLFileEntryTypeLocalServiceUtil.deleteFileEntryType(dlFileEntryType);
 	}
 
 	@Test

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionLocalServiceTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/service/test/DLFileVersionLocalServiceTest.java
@@ -91,9 +91,8 @@ public class DLFileVersionLocalServiceTest {
 				dlFileEntry.getCompanyId(), dlFileEntry.getDataRepositoryId(),
 				dlFileEntry.getName(), "1.0"));
 
-		_dlFileVersionLocalService.deleteDLFileVersion(
-			_dlFileVersionLocalService.getFileVersion(
-				fileEntry.getFileEntryId(), "1.0"));
+		_dlFileEntryLocalService.deleteFileVersion(
+			TestPropsValues.getUserId(), fileEntry.getFileEntryId(), "1.0");
 
 		Assert.assertFalse(
 			DLStoreUtil.hasFile(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
@@ -127,8 +127,10 @@ public class DDMFormInstanceTestUtil {
 		return ddmFormValues;
 	}
 
-	public static void deleteDDMFormInstance(DDMFormInstance ddmFormInstance) {
-		DDMFormInstanceLocalServiceUtil.deleteDDMFormInstance(ddmFormInstance);
+	public static void deleteDDMFormInstance(DDMFormInstance ddmFormInstance)
+		throws PortalException {
+
+		DDMFormInstanceLocalServiceUtil.deleteFormInstance(ddmFormInstance);
 	}
 
 	public static DDMFormInstance updateDDMFormInstance(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
@@ -69,6 +69,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
@@ -169,11 +170,20 @@ public class DDMFormValuesExportImportContentProcessorTest {
 		_journalArticleLocalService.deleteArticles(_liveGroup.getGroupId());
 
 		if (_ddmTemplate != null) {
-			_ddmTemplateLocalService.deleteDDMTemplate(_ddmTemplate);
+			_ddmTemplateLocalService.deleteTemplate(_ddmTemplate);
 		}
 
 		if (_ddmStructure != null) {
-			_ddmStructureLocalService.deleteDDMStructure(_ddmStructure);
+			boolean deleteInProcess = GroupThreadLocal.isDeleteInProcess();
+
+			try {
+				GroupThreadLocal.setDeleteInProcess(true);
+
+				_ddmStructureLocalService.deleteStructure(_ddmStructure);
+			}
+			finally {
+				GroupThreadLocal.setDeleteInProcess(deleteInProcess);
+			}
 		}
 	}
 
@@ -229,7 +239,7 @@ public class DDMFormValuesExportImportContentProcessorTest {
 
 		newDLFileEntry.setUuid(_fileEntry.getUuid());
 
-		_dlFileEntryLocalService.deleteDLFileEntry(fileEntryId);
+		_dlFileEntryLocalService.deleteFileEntry(fileEntryId);
 
 		_dlFileEntryLocalService.updateDLFileEntry(newDLFileEntry);
 
@@ -250,7 +260,7 @@ public class DDMFormValuesExportImportContentProcessorTest {
 
 		long newDLFileEntryId = newDLFileEntry.getFileEntryId();
 
-		_dlFileEntryLocalService.deleteDLFileEntry(newDLFileEntry);
+		_dlFileEntryLocalService.deleteFileEntry(newDLFileEntry);
 
 		Assert.assertEquals(newDLFileEntryId, jsonObject2.getLong("classPK"));
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMFormInstanceReportLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMFormInstanceReportLocalServiceTest.java
@@ -127,9 +127,7 @@ public class DDMFormInstanceReportLocalServiceTest
 
 		Assert.assertNotNull(ddmFormInstanceReport);
 
-		_ddmFormInstance =
-			DDMFormInstanceLocalServiceUtil.deleteDDMFormInstance(
-				_ddmFormInstance);
+		DDMFormInstanceTestUtil.deleteDDMFormInstance(_ddmFormInstance);
 
 		_ddmFormInstanceReportLocalService.
 			getFormInstanceReportByFormInstanceId(
@@ -168,7 +166,7 @@ public class DDMFormInstanceReportLocalServiceTest
 		DDMFormInstanceRecord ddmFormInstanceRecord =
 			createDDMFormInstanceRecord();
 
-		_ddmFormInstanceRecordLocalService.deleteDDMFormInstanceRecord(
+		_ddmFormInstanceRecordLocalService.deleteFormInstanceRecord(
 			ddmFormInstanceRecord);
 
 		DDMFormInstanceReport ddmFormInstanceReport =

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
@@ -755,7 +755,7 @@ public class DDMStructureLocalServiceTest extends BaseDDMServiceTestCase {
 
 		PermissionThreadLocal.setPermissionChecker(originalPermissionChecker);
 
-		DDMStructureLocalServiceUtil.deleteDDMStructure(structure);
+		DDMStructureLocalServiceUtil.deleteStructure(structure);
 
 		UserLocalServiceUtil.deleteUser(user);
 	}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/info/collection/provider/test/DDMStructureRelatedInfoCollectionProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/info/collection/provider/test/DDMStructureRelatedInfoCollectionProviderTest.java
@@ -77,7 +77,7 @@ public class DDMStructureRelatedInfoCollectionProviderTest {
 		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
 			_group.getGroupId(), JournalArticle.class.getName());
 
-		_ddmStructureLocalService.deleteDDMStructure(ddmStructure);
+		_ddmStructureLocalService.deleteStructure(ddmStructure);
 
 		RelatedInfoItemCollectionProvider<?, ?>
 			relatedInfoItemCollectionProvider =

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -406,6 +407,11 @@ public class JournalArticleLocalServiceTest {
 				PortalUtil.getClassNameId(JournalArticle.class),
 				curArticle.getPrimaryKey());
 
+			_resourceLocalService.deleteResource(
+				curArticle.getCompanyId(), JournalArticle.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				curArticle.getResourcePrimKey());
+
 			_journalArticleLocalService.deleteJournalArticle(
 				curArticle.getPrimaryKey());
 		}
@@ -560,6 +566,9 @@ public class JournalArticleLocalServiceTest {
 
 	@Inject
 	private Portal _portal;
+
+	@Inject
+	private ResourceLocalService _resourceLocalService;
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalTestUtilTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/util/test/JournalTestUtilTest.java
@@ -243,7 +243,7 @@ public class JournalTestUtilTest {
 				ddmStructure.getStructureKey(), null,
 				LocaleUtil.getSiteDefault()));
 
-		DDMStructureLocalServiceUtil.deleteDDMStructure(ddmStructure);
+		DDMStructureLocalServiceUtil.deleteStructure(ddmStructure);
 
 		try {
 			Assert.assertNull(

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderLocalServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderLocalServiceImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -130,6 +131,12 @@ public class KBFolderLocalServiceImpl extends KBFolderLocalServiceBaseImpl {
 		for (KBFolder childKBFolder : childKBFolders) {
 			deleteKBFolder(childKBFolder.getKbFolderId());
 		}
+
+		// Resources
+
+		resourceLocalService.deleteResource(
+			kbFolder.getCompanyId(), KBFolder.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, kbFolder.getKbFolderId());
 
 		// Expando
 

--- a/modules/apps/list-type/list-type-service/src/main/java/com/liferay/list/type/service/impl/ListTypeDefinitionLocalServiceImpl.java
+++ b/modules/apps/list-type/list-type-service/src/main/java/com/liferay/list/type/service/impl/ListTypeDefinitionLocalServiceImpl.java
@@ -95,6 +95,9 @@ public class ListTypeDefinitionLocalServiceImpl
 			throw new RequiredListTypeDefinitionException();
 		}
 
+		_resourceLocalService.deleteResource(
+			listTypeDefinition, ResourceConstants.SCOPE_INDIVIDUAL);
+
 		listTypeDefinition = listTypeDefinitionPersistence.remove(
 			listTypeDefinition);
 
@@ -114,12 +117,7 @@ public class ListTypeDefinitionLocalServiceImpl
 			listTypeDefinitionPersistence.findByPrimaryKey(
 				listTypeDefinitionId);
 
-		listTypeDefinition = deleteListTypeDefinition(listTypeDefinition);
-
-		_resourceLocalService.deleteResource(
-			listTypeDefinition, ResourceConstants.SCOPE_INDIVIDUAL);
-
-		return listTypeDefinition;
+		return deleteListTypeDefinition(listTypeDefinition);
 	}
 
 	@Indexable(type = IndexableType.REINDEX)

--- a/modules/apps/microblogs/microblogs-service/src/main/java/com/liferay/microblogs/service/impl/MicroblogsEntryLocalServiceImpl.java
+++ b/modules/apps/microblogs/microblogs-service/src/main/java/com/liferay/microblogs/service/impl/MicroblogsEntryLocalServiceImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
@@ -246,6 +247,14 @@ public class MicroblogsEntryLocalServiceImpl
 
 			_assetEntryLocalService.deleteEntry(
 				MicroblogsEntry.class.getName(),
+				curMicroblogsEntry.getMicroblogsEntryId());
+
+			// Resource
+
+			resourceLocalService.deleteResource(
+				curMicroblogsEntry.getCompanyId(),
+				MicroblogsEntry.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
 				curMicroblogsEntry.getMicroblogsEntryId());
 
 			// Social

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupInstanceLocalService.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupInstanceLocalService.java
@@ -107,7 +107,8 @@ public interface MDRRuleGroupInstanceLocalService
 	public PersistedModel createPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
-	public void deleteGroupRuleGroupInstances(long groupId);
+	public void deleteGroupRuleGroupInstances(long groupId)
+		throws PortalException;
 
 	/**
 	 * Deletes the mdr rule group instance with the primary key from the database. Also notifies the appropriate model listeners.
@@ -146,15 +147,18 @@ public interface MDRRuleGroupInstanceLocalService
 	public PersistedModel deletePersistedModel(PersistedModel persistedModel)
 		throws PortalException;
 
-	public void deleteRuleGroupInstance(long ruleGroupInstanceId);
+	public void deleteRuleGroupInstance(long ruleGroupInstanceId)
+		throws PortalException;
 
 	@SystemEvent(
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public void deleteRuleGroupInstance(MDRRuleGroupInstance ruleGroupInstance);
+	public void deleteRuleGroupInstance(MDRRuleGroupInstance ruleGroupInstance)
+		throws PortalException;
 
-	public void deleteRuleGroupInstances(long ruleGroupId);
+	public void deleteRuleGroupInstances(long ruleGroupId)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupInstanceLocalServiceUtil.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupInstanceLocalServiceUtil.java
@@ -102,7 +102,9 @@ public class MDRRuleGroupInstanceLocalServiceUtil {
 		return getService().createPersistedModel(primaryKeyObj);
 	}
 
-	public static void deleteGroupRuleGroupInstances(long groupId) {
+	public static void deleteGroupRuleGroupInstances(long groupId)
+		throws PortalException {
+
 		getService().deleteGroupRuleGroupInstances(groupId);
 	}
 
@@ -150,17 +152,22 @@ public class MDRRuleGroupInstanceLocalServiceUtil {
 		return getService().deletePersistedModel(persistedModel);
 	}
 
-	public static void deleteRuleGroupInstance(long ruleGroupInstanceId) {
+	public static void deleteRuleGroupInstance(long ruleGroupInstanceId)
+		throws PortalException {
+
 		getService().deleteRuleGroupInstance(ruleGroupInstanceId);
 	}
 
 	public static void deleteRuleGroupInstance(
-		MDRRuleGroupInstance ruleGroupInstance) {
+			MDRRuleGroupInstance ruleGroupInstance)
+		throws PortalException {
 
 		getService().deleteRuleGroupInstance(ruleGroupInstance);
 	}
 
-	public static void deleteRuleGroupInstances(long ruleGroupId) {
+	public static void deleteRuleGroupInstances(long ruleGroupId)
+		throws PortalException {
+
 		getService().deleteRuleGroupInstances(ruleGroupId);
 	}
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupInstanceLocalServiceWrapper.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupInstanceLocalServiceWrapper.java
@@ -107,7 +107,9 @@ public class MDRRuleGroupInstanceLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteGroupRuleGroupInstances(long groupId) {
+	public void deleteGroupRuleGroupInstances(long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_mdrRuleGroupInstanceLocalService.deleteGroupRuleGroupInstances(
 			groupId);
 	}
@@ -165,22 +167,27 @@ public class MDRRuleGroupInstanceLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteRuleGroupInstance(long ruleGroupInstanceId) {
+	public void deleteRuleGroupInstance(long ruleGroupInstanceId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_mdrRuleGroupInstanceLocalService.deleteRuleGroupInstance(
 			ruleGroupInstanceId);
 	}
 
 	@Override
 	public void deleteRuleGroupInstance(
-		com.liferay.mobile.device.rules.model.MDRRuleGroupInstance
-			ruleGroupInstance) {
+			com.liferay.mobile.device.rules.model.MDRRuleGroupInstance
+				ruleGroupInstance)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_mdrRuleGroupInstanceLocalService.deleteRuleGroupInstance(
 			ruleGroupInstance);
 	}
 
 	@Override
-	public void deleteRuleGroupInstances(long ruleGroupId) {
+	public void deleteRuleGroupInstances(long ruleGroupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_mdrRuleGroupInstanceLocalService.deleteRuleGroupInstances(ruleGroupId);
 	}
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupLocalService.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupLocalService.java
@@ -147,15 +147,15 @@ public interface MDRRuleGroupLocalService
 	public PersistedModel deletePersistedModel(PersistedModel persistedModel)
 		throws PortalException;
 
-	public void deleteRuleGroup(long ruleGroupId);
+	public void deleteRuleGroup(long ruleGroupId) throws PortalException;
 
 	@SystemEvent(
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public void deleteRuleGroup(MDRRuleGroup ruleGroup);
+	public void deleteRuleGroup(MDRRuleGroup ruleGroup) throws PortalException;
 
-	public void deleteRuleGroups(long groupId);
+	public void deleteRuleGroups(long groupId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupLocalServiceUtil.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupLocalServiceUtil.java
@@ -149,15 +149,19 @@ public class MDRRuleGroupLocalServiceUtil {
 		return getService().deletePersistedModel(persistedModel);
 	}
 
-	public static void deleteRuleGroup(long ruleGroupId) {
+	public static void deleteRuleGroup(long ruleGroupId)
+		throws PortalException {
+
 		getService().deleteRuleGroup(ruleGroupId);
 	}
 
-	public static void deleteRuleGroup(MDRRuleGroup ruleGroup) {
+	public static void deleteRuleGroup(MDRRuleGroup ruleGroup)
+		throws PortalException {
+
 		getService().deleteRuleGroup(ruleGroup);
 	}
 
-	public static void deleteRuleGroups(long groupId) {
+	public static void deleteRuleGroups(long groupId) throws PortalException {
 		getService().deleteRuleGroups(groupId);
 	}
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupLocalServiceWrapper.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-api/src/main/java/com/liferay/mobile/device/rules/service/MDRRuleGroupLocalServiceWrapper.java
@@ -159,19 +159,24 @@ public class MDRRuleGroupLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteRuleGroup(long ruleGroupId) {
+	public void deleteRuleGroup(long ruleGroupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_mdrRuleGroupLocalService.deleteRuleGroup(ruleGroupId);
 	}
 
 	@Override
 	public void deleteRuleGroup(
-		com.liferay.mobile.device.rules.model.MDRRuleGroup ruleGroup) {
+			com.liferay.mobile.device.rules.model.MDRRuleGroup ruleGroup)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		_mdrRuleGroupLocalService.deleteRuleGroup(ruleGroup);
 	}
 
 	@Override
-	public void deleteRuleGroups(long groupId) {
+	public void deleteRuleGroups(long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_mdrRuleGroupLocalService.deleteRuleGroups(groupId);
 	}
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupInstanceLocalServiceImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupInstanceLocalServiceImpl.java
@@ -24,6 +24,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -110,7 +111,9 @@ public class MDRRuleGroupInstanceLocalServiceImpl
 	}
 
 	@Override
-	public void deleteGroupRuleGroupInstances(long groupId) {
+	public void deleteGroupRuleGroupInstances(long groupId)
+		throws PortalException {
+
 		List<MDRRuleGroupInstance> ruleGroupInstances =
 			mdrRuleGroupInstancePersistence.findByGroupId(groupId);
 
@@ -121,7 +124,9 @@ public class MDRRuleGroupInstanceLocalServiceImpl
 	}
 
 	@Override
-	public void deleteRuleGroupInstance(long ruleGroupInstanceId) {
+	public void deleteRuleGroupInstance(long ruleGroupInstanceId)
+		throws PortalException {
+
 		MDRRuleGroupInstance ruleGroupInstance =
 			mdrRuleGroupInstancePersistence.fetchByPrimaryKey(
 				ruleGroupInstanceId);
@@ -135,8 +140,13 @@ public class MDRRuleGroupInstanceLocalServiceImpl
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public void deleteRuleGroupInstance(
-		MDRRuleGroupInstance ruleGroupInstance) {
+	public void deleteRuleGroupInstance(MDRRuleGroupInstance ruleGroupInstance)
+		throws PortalException {
+
+		// Resource
+
+		_resourceLocalService.deleteResource(
+			ruleGroupInstance, ResourceConstants.SCOPE_INDIVIDUAL);
 
 		// Rule group instance
 
@@ -169,7 +179,9 @@ public class MDRRuleGroupInstanceLocalServiceImpl
 	}
 
 	@Override
-	public void deleteRuleGroupInstances(long ruleGroupId) {
+	public void deleteRuleGroupInstances(long ruleGroupId)
+		throws PortalException {
+
 		List<MDRRuleGroupInstance> ruleGroupInstances =
 			mdrRuleGroupInstancePersistence.findByRuleGroupId(ruleGroupId);
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupLocalServiceImpl.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/service/impl/MDRRuleGroupLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ResourceLocalService;
@@ -129,7 +130,7 @@ public class MDRRuleGroupLocalServiceImpl
 	}
 
 	@Override
-	public void deleteRuleGroup(long ruleGroupId) {
+	public void deleteRuleGroup(long ruleGroupId) throws PortalException {
 		MDRRuleGroup ruleGroup = mdrRuleGroupPersistence.fetchByPrimaryKey(
 			ruleGroupId);
 
@@ -143,7 +144,12 @@ public class MDRRuleGroupLocalServiceImpl
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public void deleteRuleGroup(MDRRuleGroup ruleGroup) {
+	public void deleteRuleGroup(MDRRuleGroup ruleGroup) throws PortalException {
+
+		// Resource
+
+		_resourceLocalService.deleteResource(
+			ruleGroup, ResourceConstants.SCOPE_INDIVIDUAL);
 
 		// Rule group
 
@@ -160,7 +166,7 @@ public class MDRRuleGroupLocalServiceImpl
 	}
 
 	@Override
-	public void deleteRuleGroups(long groupId) {
+	public void deleteRuleGroups(long groupId) throws PortalException {
 		List<MDRRuleGroup> ruleGroups = mdrRuleGroupPersistence.findByGroupId(
 			groupId);
 

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/exportimport/data/handler/MDRRuleGroupInstanceStagedModelDataHandler.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/exportimport/data/handler/MDRRuleGroupInstanceStagedModelDataHandler.java
@@ -25,6 +25,7 @@ import com.liferay.mobile.device.rules.model.MDRRuleGroupInstance;
 import com.liferay.mobile.device.rules.service.MDRRuleGroupInstanceLocalService;
 import com.liferay.mobile.device.rules.service.MDRRuleGroupLocalService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -52,14 +53,17 @@ public class MDRRuleGroupInstanceStagedModelDataHandler
 	};
 
 	@Override
-	public void deleteStagedModel(MDRRuleGroupInstance ruleGroupInstance) {
+	public void deleteStagedModel(MDRRuleGroupInstance ruleGroupInstance)
+		throws PortalException {
+
 		_mdrRuleGroupInstanceLocalService.deleteRuleGroupInstance(
 			ruleGroupInstance);
 	}
 
 	@Override
 	public void deleteStagedModel(
-		String uuid, long groupId, String className, String extraData) {
+			String uuid, long groupId, String className, String extraData)
+		throws PortalException {
 
 		MDRRuleGroupInstance ruleGroupInstance =
 			fetchStagedModelByUuidAndGroupId(uuid, groupId);

--- a/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/exportimport/data/handler/MDRRuleGroupStagedModelDataHandler.java
+++ b/modules/apps/mobile-device-rules/mobile-device-rules-web/src/main/java/com/liferay/mobile/device/rules/web/internal/exportimport/data/handler/MDRRuleGroupStagedModelDataHandler.java
@@ -22,6 +22,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
 import com.liferay.mobile.device.rules.model.MDRRuleGroup;
 import com.liferay.mobile.device.rules.service.MDRRuleGroupLocalService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.xml.Element;
 
@@ -41,13 +42,16 @@ public class MDRRuleGroupStagedModelDataHandler
 	public static final String[] CLASS_NAMES = {MDRRuleGroup.class.getName()};
 
 	@Override
-	public void deleteStagedModel(MDRRuleGroup ruleGroup) {
+	public void deleteStagedModel(MDRRuleGroup ruleGroup)
+		throws PortalException {
+
 		_mdrRuleGroupLocalService.deleteRuleGroup(ruleGroup);
 	}
 
 	@Override
 	public void deleteStagedModel(
-		String uuid, long groupId, String className, String extraData) {
+			String uuid, long groupId, String className, String extraData)
+		throws PortalException {
 
 		MDRRuleGroup ruleGroup = fetchStagedModelByUuidAndGroupId(
 			uuid, groupId);

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -49,6 +49,7 @@ import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.RepositoryFactory;
@@ -374,6 +375,12 @@ public class OAuth2ApplicationLocalServiceImpl
 					oAuth2ApplicationScopeAliases.
 						getOAuth2ApplicationScopeAliasesId());
 		}
+
+		OAuth2Application oAuth2Application = fetchOAuth2Application(
+			oAuth2ApplicationId);
+
+		_resourceLocalService.deleteResource(
+			oAuth2Application, ResourceConstants.SCOPE_INDIVIDUAL);
 
 		return oAuth2ApplicationPersistence.remove(oAuth2ApplicationId);
 	}

--- a/modules/apps/segments/segments-context-vocabulary-test/src/testIntegration/java/com/liferay/segments/context/vocabulary/internal/options/provider/test/AssetVocabularyConfigurationOptionsProviderTest.java
+++ b/modules/apps/segments/segments-context-vocabulary-test/src/testIntegration/java/com/liferay/segments/context/vocabulary/internal/options/provider/test/AssetVocabularyConfigurationOptionsProviderTest.java
@@ -79,7 +79,7 @@ public class AssetVocabularyConfigurationOptionsProviderTest {
 				).isPresent());
 		}
 		finally {
-			_assetVocabularyLocalService.deleteAssetVocabulary(
+			_assetVocabularyLocalService.deleteVocabulary(
 				assetVocabulary.getVocabularyId());
 		}
 	}

--- a/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/exportimport/staged/model/repository/TemplateEntryStagedModelRepository.java
+++ b/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/exportimport/staged/model/repository/TemplateEntryStagedModelRepository.java
@@ -90,7 +90,7 @@ public class TemplateEntryStagedModelRepository
 	public void deleteStagedModel(TemplateEntry templateEntry)
 		throws PortalException {
 
-		_ddmTemplateLocalService.deleteDDMTemplate(
+		_ddmTemplateLocalService.deleteTemplate(
 			templateEntry.getDDMTemplateId());
 
 		_templateEntryLocalService.deleteTemplateEntry(templateEntry);

--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/portlet/action/DeleteTemplateEntryMVCActionCommand.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/portlet/action/DeleteTemplateEntryMVCActionCommand.java
@@ -64,7 +64,7 @@ public class DeleteTemplateEntryMVCActionCommand
 				_templateEntryLocalService.deleteTemplateEntry(
 					deleteTemplateEntryId);
 
-			_ddmTemplateLocalService.deleteDDMTemplate(
+			_ddmTemplateLocalService.deleteTemplate(
 				templateEntry.getDDMTemplateId());
 		}
 	}

--- a/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/search/test/WikiPageSearchTest.java
+++ b/modules/apps/wiki/wiki-test/src/testIntegration/java/com/liferay/wiki/search/test/WikiPageSearchTest.java
@@ -133,7 +133,9 @@ public class WikiPageSearchTest extends BaseSearchTestCase {
 
 	@Override
 	protected void deleteBaseModel(long primaryKey) throws Exception {
-		WikiPageLocalServiceUtil.deleteWikiPage(primaryKey);
+		WikiPage page = WikiPageLocalServiceUtil.getPageByPageId(primaryKey);
+
+		WikiPageLocalServiceUtil.deletePage(page);
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/messaging/KaleoDefinitionVersionModelListener.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/java/com/liferay/portal/workflow/kaleo/designer/web/internal/messaging/KaleoDefinitionVersionModelListener.java
@@ -53,7 +53,7 @@ public class KaleoDefinitionVersionModelListener
 
 		try {
 			_resourceLocalService.deleteResource(
-				kaleoDefinitionVersion, ResourceConstants.SCOPE_COMPANY);
+				kaleoDefinitionVersion, ResourceConstants.SCOPE_INDIVIDUAL);
 		}
 		catch (PortalException portalException) {
 			throw new ModelListenerException(portalException);

--- a/portal-impl/src/com/liferay/portal/service/base/RepositoryLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/RepositoryLocalServiceBaseImpl.java
@@ -138,10 +138,13 @@ public abstract class RepositoryLocalServiceBaseImpl
 	 *
 	 * @param repository the repository
 	 * @return the repository that was removed
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	@Override
-	public Repository deleteRepository(Repository repository) {
+	public Repository deleteRepository(Repository repository)
+		throws PortalException {
+
 		return repositoryPersistence.remove(repository);
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1658,8 +1658,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			_actionableDynamicQuery.setCompanyId(companyId);
 			_actionableDynamicQuery.setPerformActionMethod(
 				(ExpandoColumn expandoColumn) ->
-					_expandoColumnLocalService.deleteExpandoColumn(
-						expandoColumn));
+					_expandoColumnLocalService.deleteColumn(expandoColumn));
 		}
 
 		protected void performActions() throws PortalException {

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutBranchLocalServiceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.model.LayoutBranchConstants;
 import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.model.LayoutRevisionConstants;
 import com.liferay.portal.kernel.model.LayoutSetBranch;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.RecentLayoutBranchLocalService;
@@ -135,6 +136,11 @@ public class LayoutBranchLocalServiceImpl
 			layoutBranch.getPlid());
 
 		_recentLayoutBranchLocalService.deleteRecentLayoutBranches(
+			layoutBranch.getLayoutBranchId());
+
+		_resourceLocalService.deleteResource(
+			layoutBranch.getCompanyId(), LayoutBranch.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
 			layoutBranch.getLayoutBranchId());
 
 		return deleteLayoutBranch(layoutBranch);

--- a/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RepositoryLocalServiceImpl.java
@@ -169,7 +169,9 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public Repository deleteRepository(Repository repository) {
+	public Repository deleteRepository(Repository repository)
+		throws PortalException {
+
 		_expandoValueLocalService.deleteValues(
 			Repository.class.getName(), repository.getRepositoryId());
 
@@ -177,7 +179,7 @@ public class RepositoryLocalServiceImpl extends RepositoryLocalServiceBaseImpl {
 			repository.getDlFolderId());
 
 		if (dlFolder != null) {
-			_dlFolderLocalService.deleteDLFolder(dlFolder);
+			_dlFolderLocalService.deleteFolder(dlFolder);
 		}
 
 		repositoryPersistence.remove(repository);

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -461,14 +461,9 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 				resourcePermission);
 		}
 
-		String className = role.getClassName();
-		long classNameId = role.getClassNameId();
-
-		if ((classNameId <= 0) || className.equals(Role.class.getName())) {
-			_resourceLocalService.deleteResource(
-				role.getCompanyId(), Role.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL, role.getRoleId());
-		}
+		_resourceLocalService.deleteResource(
+			role.getCompanyId(), Role.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, role.getRoleId());
 
 		if ((role.getType() == RoleConstants.TYPE_DEPOT) ||
 			(role.getType() == RoleConstants.TYPE_ORGANIZATION) ||

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFileShortcutLocalServiceImpl.java
@@ -272,7 +272,7 @@ public class DLFileShortcutLocalServiceImpl
 
 		actionableDynamicQuery.setPerformActionMethod(
 			(DLFileShortcut fileShortcut) ->
-				dlFileShortcutLocalService.deleteDLFileShortcut(fileShortcut));
+				dlFileShortcutLocalService.deleteFileShortcut(fileShortcut));
 
 		actionableDynamicQuery.performActions();
 	}

--- a/portal-impl/src/com/liferay/portlet/expando/service/base/ExpandoTableLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/base/ExpandoTableLocalServiceBaseImpl.java
@@ -138,10 +138,13 @@ public abstract class ExpandoTableLocalServiceBaseImpl
 	 *
 	 * @param expandoTable the expando table
 	 * @return the expando table that was removed
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	@Override
-	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable) {
+	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable)
+		throws PortalException {
+
 		return expandoTablePersistence.remove(expandoTable);
 	}
 

--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoColumnLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoColumnLocalServiceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.adapter.ModelAdapterUtil;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
@@ -92,7 +93,7 @@ public class ExpandoColumnLocalServiceImpl
 	}
 
 	@Override
-	public void deleteColumn(ExpandoColumn column) {
+	public void deleteColumn(ExpandoColumn column) throws PortalException {
 		addDeletionSystemEvent(column);
 
 		// Column
@@ -102,6 +103,12 @@ public class ExpandoColumnLocalServiceImpl
 		// Values
 
 		expandoValueLocalService.deleteColumnValues(column.getColumnId());
+
+		// Resources
+
+		resourceLocalService.deleteResource(
+			column.getCompanyId(), ExpandoColumn.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL, column.getColumnId());
 	}
 
 	@Override
@@ -124,7 +131,7 @@ public class ExpandoColumnLocalServiceImpl
 	}
 
 	@Override
-	public void deleteColumn(long tableId, String name) {
+	public void deleteColumn(long tableId, String name) throws PortalException {
 		ExpandoColumn column = expandoColumnPersistence.fetchByT_N(
 			tableId, name);
 
@@ -144,7 +151,7 @@ public class ExpandoColumnLocalServiceImpl
 	}
 
 	@Override
-	public void deleteColumns(long tableId) {
+	public void deleteColumns(long tableId) throws PortalException {
 		List<ExpandoColumn> columns = expandoColumnPersistence.findByTableId(
 			tableId);
 

--- a/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoTableLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/service/impl/ExpandoTableLocalServiceImpl.java
@@ -80,30 +80,32 @@ public class ExpandoTableLocalServiceImpl
 	}
 
 	@Override
-	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable) {
+	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable)
+		throws PortalException {
+
 		deleteTable(expandoTable);
 
 		return expandoTable;
 	}
 
 	@Override
-	public void deleteTable(ExpandoTable table) {
+	public void deleteTable(ExpandoTable table) throws PortalException {
 
-		// Table
+		// Values
 
-		expandoTablePersistence.remove(table);
-
-		// Columns
-
-		expandoColumnPersistence.removeByTableId(table.getTableId());
+		expandoValuePersistence.removeByTableId(table.getTableId());
 
 		// Rows
 
 		expandoRowPersistence.removeByTableId(table.getTableId());
 
-		// Values
+		// Columns
 
-		expandoValuePersistence.removeByTableId(table.getTableId());
+		expandoColumnLocalService.deleteColumns(table.getTableId());
+
+		// Table
+
+		expandoTablePersistence.remove(table);
 	}
 
 	@Override
@@ -132,7 +134,9 @@ public class ExpandoTableLocalServiceImpl
 	}
 
 	@Override
-	public void deleteTables(long companyId, long classNameId) {
+	public void deleteTables(long companyId, long classNameId)
+		throws PortalException {
+
 		List<ExpandoTable> tables = expandoTablePersistence.findByC_C(
 			companyId, classNameId);
 
@@ -142,7 +146,9 @@ public class ExpandoTableLocalServiceImpl
 	}
 
 	@Override
-	public void deleteTables(long companyId, String className) {
+	public void deleteTables(long companyId, String className)
+		throws PortalException {
+
 		deleteTables(
 			companyId, classNameLocalService.getClassNameId(className));
 	}

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoColumnLocalService.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoColumnLocalService.java
@@ -103,7 +103,7 @@ public interface ExpandoColumnLocalService
 	public PersistedModel createPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
-	public void deleteColumn(ExpandoColumn column);
+	public void deleteColumn(ExpandoColumn column) throws PortalException;
 
 	public void deleteColumn(long columnId) throws PortalException;
 
@@ -111,13 +111,13 @@ public interface ExpandoColumnLocalService
 			long companyId, long classNameId, String tableName, String name)
 		throws PortalException;
 
-	public void deleteColumn(long tableId, String name);
+	public void deleteColumn(long tableId, String name) throws PortalException;
 
 	public void deleteColumn(
 			long companyId, String className, String tableName, String name)
 		throws PortalException;
 
-	public void deleteColumns(long tableId);
+	public void deleteColumns(long tableId) throws PortalException;
 
 	public void deleteColumns(
 			long companyId, long classNameId, String tableName)

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoColumnLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoColumnLocalServiceUtil.java
@@ -91,7 +91,9 @@ public class ExpandoColumnLocalServiceUtil {
 		return getService().createPersistedModel(primaryKeyObj);
 	}
 
-	public static void deleteColumn(ExpandoColumn column) {
+	public static void deleteColumn(ExpandoColumn column)
+		throws PortalException {
+
 		getService().deleteColumn(column);
 	}
 
@@ -106,7 +108,9 @@ public class ExpandoColumnLocalServiceUtil {
 		getService().deleteColumn(companyId, classNameId, tableName, name);
 	}
 
-	public static void deleteColumn(long tableId, String name) {
+	public static void deleteColumn(long tableId, String name)
+		throws PortalException {
+
 		getService().deleteColumn(tableId, name);
 	}
 
@@ -117,7 +121,7 @@ public class ExpandoColumnLocalServiceUtil {
 		getService().deleteColumn(companyId, className, tableName, name);
 	}
 
-	public static void deleteColumns(long tableId) {
+	public static void deleteColumns(long tableId) throws PortalException {
 		getService().deleteColumns(tableId);
 	}
 

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoColumnLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoColumnLocalServiceWrapper.java
@@ -94,7 +94,9 @@ public class ExpandoColumnLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteColumn(ExpandoColumn column) {
+	public void deleteColumn(ExpandoColumn column)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_expandoColumnLocalService.deleteColumn(column);
 	}
 
@@ -115,7 +117,9 @@ public class ExpandoColumnLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteColumn(long tableId, String name) {
+	public void deleteColumn(long tableId, String name)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_expandoColumnLocalService.deleteColumn(tableId, name);
 	}
 
@@ -129,7 +133,9 @@ public class ExpandoColumnLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteColumns(long tableId) {
+	public void deleteColumns(long tableId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_expandoColumnLocalService.deleteColumns(tableId);
 	}
 

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoTableLocalService.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoTableLocalService.java
@@ -116,9 +116,11 @@ public interface ExpandoTableLocalService
 	 *
 	 * @param expandoTable the expando table
 	 * @return the expando table that was removed
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
-	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable);
+	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable)
+		throws PortalException;
 
 	/**
 	 * Deletes the expando table with the primary key from the database. Also notifies the appropriate model listeners.
@@ -141,7 +143,7 @@ public interface ExpandoTableLocalService
 	public PersistedModel deletePersistedModel(PersistedModel persistedModel)
 		throws PortalException;
 
-	public void deleteTable(ExpandoTable table);
+	public void deleteTable(ExpandoTable table) throws PortalException;
 
 	public void deleteTable(long tableId) throws PortalException;
 
@@ -151,9 +153,11 @@ public interface ExpandoTableLocalService
 	public void deleteTable(long companyId, String className, String name)
 		throws PortalException;
 
-	public void deleteTables(long companyId, long classNameId);
+	public void deleteTables(long companyId, long classNameId)
+		throws PortalException;
 
-	public void deleteTables(long companyId, String className);
+	public void deleteTables(long companyId, String className)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoTableLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoTableLocalServiceUtil.java
@@ -113,8 +113,11 @@ public class ExpandoTableLocalServiceUtil {
 	 *
 	 * @param expandoTable the expando table
 	 * @return the expando table that was removed
+	 * @throws PortalException
 	 */
-	public static ExpandoTable deleteExpandoTable(ExpandoTable expandoTable) {
+	public static ExpandoTable deleteExpandoTable(ExpandoTable expandoTable)
+		throws PortalException {
+
 		return getService().deleteExpandoTable(expandoTable);
 	}
 
@@ -145,7 +148,7 @@ public class ExpandoTableLocalServiceUtil {
 		return getService().deletePersistedModel(persistedModel);
 	}
 
-	public static void deleteTable(ExpandoTable table) {
+	public static void deleteTable(ExpandoTable table) throws PortalException {
 		getService().deleteTable(table);
 	}
 
@@ -167,11 +170,15 @@ public class ExpandoTableLocalServiceUtil {
 		getService().deleteTable(companyId, className, name);
 	}
 
-	public static void deleteTables(long companyId, long classNameId) {
+	public static void deleteTables(long companyId, long classNameId)
+		throws PortalException {
+
 		getService().deleteTables(companyId, classNameId);
 	}
 
-	public static void deleteTables(long companyId, String className) {
+	public static void deleteTables(long companyId, String className)
+		throws PortalException {
+
 		getService().deleteTables(companyId, className);
 	}
 

--- a/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoTableLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/expando/kernel/service/ExpandoTableLocalServiceWrapper.java
@@ -115,9 +115,12 @@ public class ExpandoTableLocalServiceWrapper
 	 *
 	 * @param expandoTable the expando table
 	 * @return the expando table that was removed
+	 * @throws PortalException
 	 */
 	@Override
-	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable) {
+	public ExpandoTable deleteExpandoTable(ExpandoTable expandoTable)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		return _expandoTableLocalService.deleteExpandoTable(expandoTable);
 	}
 
@@ -151,7 +154,9 @@ public class ExpandoTableLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteTable(ExpandoTable table) {
+	public void deleteTable(ExpandoTable table)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_expandoTableLocalService.deleteTable(table);
 	}
 
@@ -177,12 +182,16 @@ public class ExpandoTableLocalServiceWrapper
 	}
 
 	@Override
-	public void deleteTables(long companyId, long classNameId) {
+	public void deleteTables(long companyId, long classNameId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_expandoTableLocalService.deleteTables(companyId, classNameId);
 	}
 
 	@Override
-	public void deleteTables(long companyId, String className) {
+	public void deleteTables(long companyId, String className)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
 		_expandoTableLocalService.deleteTables(companyId, className);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalService.java
@@ -134,13 +134,15 @@ public interface RepositoryLocalService
 	 *
 	 * @param repository the repository
 	 * @return the repository that was removed
+	 * @throws PortalException
 	 */
 	@Indexable(type = IndexableType.DELETE)
 	@SystemEvent(
 		action = SystemEventConstants.ACTION_SKIP,
 		type = SystemEventConstants.TYPE_DELETE
 	)
-	public Repository deleteRepository(Repository repository);
+	public Repository deleteRepository(Repository repository)
+		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public <T> T dslQuery(DSLQuery dslQuery);

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceUtil.java
@@ -135,8 +135,11 @@ public class RepositoryLocalServiceUtil {
 	 *
 	 * @param repository the repository
 	 * @return the repository that was removed
+	 * @throws PortalException
 	 */
-	public static Repository deleteRepository(Repository repository) {
+	public static Repository deleteRepository(Repository repository)
+		throws PortalException {
+
 		return getService().deleteRepository(repository);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RepositoryLocalServiceWrapper.java
@@ -141,10 +141,12 @@ public class RepositoryLocalServiceWrapper
 	 *
 	 * @param repository the repository
 	 * @return the repository that was removed
+	 * @throws PortalException
 	 */
 	@Override
 	public com.liferay.portal.kernel.model.Repository deleteRepository(
-		com.liferay.portal.kernel.model.Repository repository) {
+			com.liferay.portal.kernel.model.Repository repository)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _repositoryLocalService.deleteRepository(repository);
 	}

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 10.1.5
+Bundle-Version: 10.2.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/OrphanDetectionTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/OrphanDetectionTestRule.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.test.rule;
+
+import com.liferay.petra.io.unsync.UnsyncPrintWriter;
+import com.liferay.petra.io.unsync.UnsyncStringWriter;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.orm.ORMException;
+import com.liferay.portal.kernel.dao.orm.Session;
+import com.liferay.portal.kernel.dao.orm.SessionCustomizer;
+import com.liferay.portal.kernel.dao.orm.SessionWrapper;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ShardedModel;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.transaction.TransactionAttribute;
+import com.liferay.portal.kernel.transaction.TransactionLifecycleListener;
+import com.liferay.portal.kernel.transaction.TransactionStatus;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.Assert;
+import org.junit.runner.Description;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Jorge Díaz
+ */
+public class OrphanDetectionTestRule
+	extends MethodTestRule<List<ServiceRegistration<?>>> {
+
+	public static final OrphanDetectionTestRule INSTANCE =
+		new OrphanDetectionTestRule();
+
+	@Override
+	protected void afterMethod(
+			Description description,
+			List<ServiceRegistration<?>> serviceRegistrations, Object target)
+		throws Throwable {
+
+		for (ServiceRegistration<?> serviceRegistration :
+				serviceRegistrations) {
+
+			serviceRegistration.unregister();
+		}
+	}
+
+	@Override
+	protected List<ServiceRegistration<?>> beforeMethod(
+			Description description, Object target)
+		throws Throwable {
+
+		Stack<Map<BaseModel<?>, String>> recordsStack = new Stack<>();
+
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		return ListUtil.fromArray(
+			bundleContext.registerService(
+				SessionCustomizer.class,
+				new OrphanDetectionSessionCustomizer(recordsStack), null),
+			bundleContext.registerService(
+				TransactionLifecycleListener.class,
+				new OrphanDetectionTransactionLifecycleListener(recordsStack),
+				null));
+	}
+
+	private OrphanDetectionTestRule() {
+	}
+
+	private static class OrphanDetectionSessionCustomizer
+		implements SessionCustomizer {
+
+		@Override
+		public Session customize(Session session) {
+			return new OrphanDetectionSessionWrapper(session, _recordsStack);
+		}
+
+		private OrphanDetectionSessionCustomizer(
+			Stack<Map<BaseModel<?>, String>> recordsStack) {
+
+			_recordsStack = recordsStack;
+		}
+
+		private Stack<Map<BaseModel<?>, String>> _recordsStack;
+
+	}
+
+	private static class OrphanDetectionSessionWrapper extends SessionWrapper {
+
+		@Override
+		public void delete(Object object) throws ORMException {
+			super.delete(object);
+
+			if (object instanceof BaseModel<?>) {
+				_record(object);
+			}
+		}
+
+		private OrphanDetectionSessionWrapper(
+			Session session, Stack<Map<BaseModel<?>, String>> recordsStack) {
+
+			super(session);
+
+			_recordsStack = recordsStack;
+		}
+
+		private void _record(Object object) {
+			if (_recordsStack.isEmpty()) {
+				return;
+			}
+
+			BaseModel<?> baseModel = (BaseModel<?>)object;
+
+			if (baseModel.isNew()) {
+				return;
+			}
+
+			UnsyncStringWriter unsyncStringWriter = new UnsyncStringWriter();
+
+			Exception exception = new Exception();
+
+			exception.printStackTrace(
+				new UnsyncPrintWriter(unsyncStringWriter));
+
+			Map<BaseModel<?>, String> records = _recordsStack.peek();
+
+			records.put(baseModel, unsyncStringWriter.toString());
+		}
+
+		private Stack<Map<BaseModel<?>, String>> _recordsStack;
+
+	}
+
+	private static class OrphanDetectionTransactionLifecycleListener
+		implements TransactionLifecycleListener {
+
+		@Override
+		public void committed(
+			TransactionAttribute transactionAttribute,
+			TransactionStatus transactionStatus) {
+
+			Map<BaseModel<?>, String> records = _recordsStack.pop();
+
+			for (Map.Entry<BaseModel<?>, String> entry : records.entrySet()) {
+				BaseModel<?> baseModel = entry.getKey();
+
+				if (!(baseModel instanceof ShardedModel)) {
+					continue;
+				}
+
+				ShardedModel shardedModel = (ShardedModel)baseModel;
+
+				int count =
+					ResourcePermissionLocalServiceUtil.
+						getResourcePermissionsCount(
+							shardedModel.getCompanyId(),
+							baseModel.getModelClassName(),
+							ResourceConstants.SCOPE_INDIVIDUAL,
+							String.valueOf(baseModel.getPrimaryKeyObj()));
+
+				Assert.assertEquals(
+					StringBundler.concat(
+						"Orphan ResourcePermission after the deletion of ",
+						baseModel.getModelClassName(), ": ", baseModel,
+						" with backtraceInfo ", entry.getValue()),
+					0, count);
+			}
+		}
+
+		@Override
+		public void created(
+			TransactionAttribute transactionAttribute,
+			TransactionStatus transactionStatus) {
+
+			_recordsStack.push(new ConcurrentHashMap<>());
+		}
+
+		@Override
+		public void rollbacked(
+			TransactionAttribute transactionAttribute,
+			TransactionStatus transactionStatus, Throwable throwable) {
+
+			_recordsStack.pop();
+		}
+
+		private OrphanDetectionTransactionLifecycleListener(
+			Stack<Map<BaseModel<?>, String>> recordsStack) {
+
+			_recordsStack = recordsStack;
+		}
+
+		private Stack<Map<BaseModel<?>, String>> _recordsStack;
+
+	}
+
+}

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/OrphanDetectionTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/OrphanDetectionTestRule.java
@@ -21,11 +21,19 @@ import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.SessionCustomizer;
 import com.liferay.portal.kernel.dao.orm.SessionWrapper;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistryUtil;
+import com.liferay.portal.kernel.service.PersistedResourcedModelLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.transaction.TransactionAttribute;
 import com.liferay.portal.kernel.transaction.TransactionLifecycleListener;
 import com.liferay.portal.kernel.transaction.TransactionStatus;
@@ -160,6 +168,9 @@ public class OrphanDetectionTestRule
 
 			Map<BaseModel<?>, String> records = _recordsStack.pop();
 
+			Map<String, PersistedModelLocalService>
+				persistedModelLocalServices = _getPersistedModelLocalServices();
+
 			for (Map.Entry<BaseModel<?>, String> entry : records.entrySet()) {
 				BaseModel<?> baseModel = entry.getKey();
 
@@ -183,6 +194,17 @@ public class OrphanDetectionTestRule
 						baseModel.getModelClassName(), ": ", baseModel,
 						" with backtraceInfo ", entry.getValue()),
 					0, count);
+
+				if (baseModel instanceof ResourcedModel) {
+					try {
+						_checkResourceModelResourcePermissions(
+							baseModel, entry.getValue(),
+							persistedModelLocalServices);
+					}
+					catch (PortalException portalException) {
+						throw new SystemException(portalException);
+					}
+				}
 			}
 		}
 
@@ -206,6 +228,61 @@ public class OrphanDetectionTestRule
 			Stack<Map<BaseModel<?>, String>> recordsStack) {
 
 			_recordsStack = recordsStack;
+		}
+
+		private void _checkResourceModelResourcePermissions(
+				BaseModel<?> baseModel, String backtraceInfo,
+				Map<String, PersistedModelLocalService>
+					persistedModelLocalServices)
+			throws PortalException {
+
+			PersistedModelLocalService persistedModelLocalService =
+				persistedModelLocalServices.get(baseModel.getModelClassName());
+
+			if (!(persistedModelLocalService instanceof
+					PersistedResourcedModelLocalService)) {
+
+				return;
+			}
+
+			ResourcedModel resourcedModel = (ResourcedModel)baseModel;
+
+			PersistedResourcedModelLocalService
+				persistedResourcedModelLocalService =
+					(PersistedResourcedModelLocalService)
+						persistedModelLocalService;
+
+			List<? extends PersistedModel> persistedResourcedModels =
+				persistedResourcedModelLocalService.getPersistedModel(
+					resourcedModel.getResourcePrimKey());
+
+			if (!persistedResourcedModels.isEmpty()) {
+				return;
+			}
+
+			ShardedModel shardedModel = (ShardedModel)baseModel;
+
+			int count =
+				ResourcePermissionLocalServiceUtil.getResourcePermissionsCount(
+					shardedModel.getCompanyId(), baseModel.getModelClassName(),
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourcedModel.getResourcePrimKey()));
+
+			Assert.assertEquals(
+				StringBundler.concat(
+					"Orphan ResourcePermission after the deletion of ",
+					baseModel.getModelClassName(), ": ", baseModel,
+					" with backtraceInfo ", backtraceInfo),
+				0, count);
+		}
+
+		private Map<String, PersistedModelLocalService>
+			_getPersistedModelLocalServices() {
+
+			return ReflectionTestUtil.getFieldValue(
+				PersistedModelLocalServiceRegistryUtil.
+					getPersistedModelLocalServiceRegistry(),
+				"_persistedModelLocalServices");
 		}
 
 		private Stack<Map<BaseModel<?>, String>> _recordsStack;

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/portal-test/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/LiferayIntegrationTestRule.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CompanyProviderClassTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuardTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRunMethodTestRule;
+import com.liferay.portal.kernel.test.rule.OrphanDetectionTestRule;
 import com.liferay.portal.kernel.test.rule.PortalRunModeClassTestRule;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
 import com.liferay.portal.kernel.test.rule.TimeoutTestRule;
@@ -52,6 +53,7 @@ public class LiferayIntegrationTestRule extends AggregateTestRule {
 		testRules.add(UniqueStringRandomizerBumperClassTestRule.INSTANCE);
 		testRules.add(CompanyProviderClassTestRule.INSTANCE);
 		testRules.add(DeleteAfterTestRunMethodTestRule.INSTANCE);
+		testRules.add(OrphanDetectionTestRule.INSTANCE);
 		testRules.add(InjectTestRule.INSTANCE);
 		testRules.add(PortalRunModeClassTestRule.INSTANCE);
 


### PR DESCRIPTION
- LPS-145396 OrphanDetectionTestRule: Add new test rule that tracks all deleted objects during test execution and checks that no ResourcePermission is left at database commit time
- LPS-145396 OrphanDetectionTestRule: Check ResourcePermissions deletion for ResourceModel objects. These objects create the ResourcePermissions using the resourcePrimKey, that is shared, so it is only orphaned when the last one is deleted
- LPS-145396 OrphanDetectionTestRule: Fix false positives in tests, replacing *LocalServiceBaseImpl delete method calls with *LocalServiceImpl ones
- LPS-145396 Semver
- LPS-145396 Delete the resource permission of ExpandoColumn objects. Fix the deletion order in deleteTable method.
- LPS-145396 Delete the resource permission of KBFolder objects
- LPS-145396 Delete the resource permission of LayoutBranch objects
- LPS-145396 Delete the resource permission of ListTypeDefinition objects
- LPS-145396 Delete the resource permission of MicroblogsEntry objects
- LPS-145396 Delete the resource permission of OAuth2Application objects
- LPS-145396 Delete the resource permission of Role objects
- LPS-145396 Delete the resource permission of KaleoDefinitionVersion objects in the correct scope SCOPE_INDIVIDUAL
- LPS-145396 Delete the resource permission of BatchPlannerPlan objects in the correct scope SCOPE_INDIVIDUAL
- LPS-145396 Replace *LocalServiceBaseImpl delete method calls with *LocalServiceImpl ones
- LPS-145396 Avoid error when it is called from the listener if the group doesn't exist
- LPS-145396 Delete the resource permission of MDRRuleGroup and MDRRuleGroupInstance objects
- LPS-145396 Autogenerate build service
