### PR TITLE
LPS-149185 Fix false positives in tests due to orphan ResourcePermission - Bravo team - LPS-145396 Subtask

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
@@ -40,9 +40,18 @@ public class DDMFormInstanceTestUtil {
 		throws Exception {
 
 		return addDDMFormInstance(
+			ddmForm, group, settingsDDMFormValues,
+			DDMFormInstance.class.getName(), userId);
+	}
+
+	public static DDMFormInstance addDDMFormInstance(
+			DDMForm ddmForm, Group group, DDMFormValues settingsDDMFormValues,
+			String className, long userId)
+		throws Exception {
+
+		return addDDMFormInstance(
 			DDMStructureTestUtil.addStructure(
-				group.getGroupId(), DDMFormInstance.class.getName(), ddmForm,
-				LocaleUtil.US),
+				group.getGroupId(), className, ddmForm, LocaleUtil.US),
 			group, settingsDDMFormValues, userId);
 	}
 
@@ -52,6 +61,14 @@ public class DDMFormInstanceTestUtil {
 
 		return addDDMFormInstance(
 			ddmForm, group, createSettingsDDMFormValues(), userId);
+	}
+
+	public static DDMFormInstance addDDMFormInstance(
+			DDMForm ddmForm, Group group, String className, long userId)
+		throws Exception {
+
+		return addDDMFormInstance(
+			ddmForm, group, createSettingsDDMFormValues(), className, userId);
 	}
 
 	public static DDMFormInstance addDDMFormInstance(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test-util/src/main/java/com/liferay/dynamic/data/mapping/test/util/DDMFormInstanceTestUtil.java
@@ -127,8 +127,10 @@ public class DDMFormInstanceTestUtil {
 		return ddmFormValues;
 	}
 
-	public static void deleteDDMFormInstance(DDMFormInstance ddmFormInstance) {
-		DDMFormInstanceLocalServiceUtil.deleteDDMFormInstance(ddmFormInstance);
+	public static void deleteDDMFormInstance(DDMFormInstance ddmFormInstance)
+		throws PortalException {
+
+		DDMFormInstanceLocalServiceUtil.deleteFormInstance(ddmFormInstance);
 	}
 
 	public static DDMFormInstance updateDDMFormInstance(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
@@ -69,6 +69,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
@@ -169,11 +170,20 @@ public class DDMFormValuesExportImportContentProcessorTest {
 		_journalArticleLocalService.deleteArticles(_liveGroup.getGroupId());
 
 		if (_ddmTemplate != null) {
-			_ddmTemplateLocalService.deleteDDMTemplate(_ddmTemplate);
+			_ddmTemplateLocalService.deleteTemplate(_ddmTemplate);
 		}
 
 		if (_ddmStructure != null) {
-			_ddmStructureLocalService.deleteDDMStructure(_ddmStructure);
+			boolean deleteInProcess = GroupThreadLocal.isDeleteInProcess();
+
+			try {
+				GroupThreadLocal.setDeleteInProcess(true);
+
+				_ddmStructureLocalService.deleteStructure(_ddmStructure);
+			}
+			finally {
+				GroupThreadLocal.setDeleteInProcess(deleteInProcess);
+			}
 		}
 	}
 
@@ -229,7 +239,7 @@ public class DDMFormValuesExportImportContentProcessorTest {
 
 		newDLFileEntry.setUuid(_fileEntry.getUuid());
 
-		_dlFileEntryLocalService.deleteDLFileEntry(fileEntryId);
+		_dlFileEntryLocalService.deleteFileEntry(fileEntryId);
 
 		_dlFileEntryLocalService.updateDLFileEntry(newDLFileEntry);
 
@@ -250,7 +260,7 @@ public class DDMFormValuesExportImportContentProcessorTest {
 
 		long newDLFileEntryId = newDLFileEntry.getFileEntryId();
 
-		_dlFileEntryLocalService.deleteDLFileEntry(newDLFileEntry);
+		_dlFileEntryLocalService.deleteFileEntry(newDLFileEntry);
 
 		Assert.assertEquals(newDLFileEntryId, jsonObject2.getLong("classPK"));
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/internal/exportimport/content/processor/test/DDMFormValuesExportImportContentProcessorTest.java
@@ -392,7 +392,8 @@ public class DDMFormValuesExportImportContentProcessorTest {
 		return journalDDMForm;
 	}
 
-	private DDMFormInstance _createFormInstanceWithDocLib(Group group)
+	private DDMFormInstance _createFormInstanceWithDocLib(
+			Group group, String className)
 		throws Exception {
 
 		DDMForm ddmForm = DDMFormTestUtil.createDDMForm();
@@ -401,7 +402,7 @@ public class DDMFormValuesExportImportContentProcessorTest {
 			ddmForm, "DocumentsAndMedia9t17");
 
 		return DDMFormInstanceTestUtil.addDDMFormInstance(
-			ddmForm, group, TestPropsValues.getUserId());
+			ddmForm, group, className, TestPropsValues.getUserId());
 	}
 
 	private void _initDLReferences() throws Exception {
@@ -421,7 +422,8 @@ public class DDMFormValuesExportImportContentProcessorTest {
 		_fileEntry = thumbnailCapability.setLargeImageId(
 			_fileEntry, _fileEntry.getFileEntryId());
 
-		_formInstance = _createFormInstanceWithDocLib(_stagingGroup);
+		_formInstance = _createFormInstanceWithDocLib(
+			_stagingGroup, JournalArticle.class.getName());
 
 		DDMStructure structure = _formInstance.getStructure();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMFormInstanceReportLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMFormInstanceReportLocalServiceTest.java
@@ -127,9 +127,7 @@ public class DDMFormInstanceReportLocalServiceTest
 
 		Assert.assertNotNull(ddmFormInstanceReport);
 
-		_ddmFormInstance =
-			DDMFormInstanceLocalServiceUtil.deleteDDMFormInstance(
-				_ddmFormInstance);
+		DDMFormInstanceTestUtil.deleteDDMFormInstance(_ddmFormInstance);
 
 		_ddmFormInstanceReportLocalService.
 			getFormInstanceReportByFormInstanceId(
@@ -168,7 +166,7 @@ public class DDMFormInstanceReportLocalServiceTest
 		DDMFormInstanceRecord ddmFormInstanceRecord =
 			createDDMFormInstanceRecord();
 
-		_ddmFormInstanceRecordLocalService.deleteDDMFormInstanceRecord(
+		_ddmFormInstanceRecordLocalService.deleteFormInstanceRecord(
 			ddmFormInstanceRecord);
 
 		DDMFormInstanceReport ddmFormInstanceReport =

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
@@ -755,7 +755,7 @@ public class DDMStructureLocalServiceTest extends BaseDDMServiceTestCase {
 
 		PermissionThreadLocal.setPermissionChecker(originalPermissionChecker);
 
-		DDMStructureLocalServiceUtil.deleteDDMStructure(structure);
+		DDMStructureLocalServiceUtil.deleteStructure(structure);
 
 		UserLocalServiceUtil.deleteUser(user);
 	}


### PR DESCRIPTION
In parent LPS-145396 I am going to add some changes in DataGuardTestRule to detect orphan ResourcePermission records, avoiding the bug in the future.

In this LPS I am fixing some false positives in tests for DDM Bravo team code.

The false positives are caused because in some tests we call LocalServiceBaseImpl delete methods instead of calling the LocalServiceImpl ones and because in a test we create a structure with a wrong className

