### PR TITLE
LPS-145396_tests_data_orphan_mod_6b

### DIFF
--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/closure/test/CTClosureFactoryImplTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/closure/test/CTClosureFactoryImplTest.java
@@ -194,8 +194,7 @@ public class CTClosureFactoryImplTest {
 					"CTCollectionLocalServiceImpl",
 				LoggerTestUtil.WARN)) {
 
-			_ctCollectionLocalService.deleteCTCollection(
-				_ctCollection.getCtCollectionId());
+			_ctCollectionLocalService.deleteCTCollection(_ctCollection);
 		}
 
 		_db.runSQL("drop table GrandParentTable");

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/test/CPDisplayLayoutLocalServiceTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/service/test/CPDisplayLayoutLocalServiceTest.java
@@ -157,7 +157,7 @@ public class CPDisplayLayoutLocalServiceTest {
 
 		Assert.assertEquals(
 			2, _cpDisplayLayoutLocalService.getCPDisplayLayoutsCount());
-		AssetCategoryLocalServiceUtil.deleteAssetCategory(assetCategory);
+		AssetCategoryLocalServiceUtil.deleteCategory(assetCategory);
 		Assert.assertEquals(
 			0, _cpDisplayLayoutLocalService.getCPDisplayLayoutsCount());
 	}

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/util/test/CPDefinitionHelperTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/util/test/CPDefinitionHelperTest.java
@@ -212,7 +212,7 @@ public class CPDefinitionHelperTest {
 		Assert.assertTrue(
 			actualCPDefinitionIds.containsAll(cpDefinitionIdsList));
 
-		AssetCategoryLocalServiceUtil.deleteAssetCategory(
+		AssetCategoryLocalServiceUtil.deleteCategory(
 			assetCategory.getCategoryId());
 	}
 

--- a/modules/apps/portal-security/portal-security-permission-test-util/src/main/java/com/liferay/portal/security/permission/test/util/BasePermissionTestCase.java
+++ b/modules/apps/portal-security/portal-security-permission-test-util/src/main/java/com/liferay/portal/security/permission/test/util/BasePermissionTestCase.java
@@ -69,7 +69,7 @@ public abstract class BasePermissionTestCase {
 	protected void addPortletModelViewPermission() throws Exception {
 		RoleTestUtil.addResourcePermission(
 			getRoleName(), getResourceName(), ResourceConstants.SCOPE_GROUP,
-			getPrimKey(), ActionKeys.VIEW);
+			String.valueOf(group.getGroupId()), ActionKeys.VIEW);
 
 		Role role = RoleLocalServiceUtil.getRole(
 			TestPropsValues.getCompanyId(), getRoleName());
@@ -95,7 +95,7 @@ public abstract class BasePermissionTestCase {
 	protected void removePortletModelViewPermission() throws Exception {
 		RoleTestUtil.removeResourcePermission(
 			getRoleName(), getResourceName(), ResourceConstants.SCOPE_GROUP,
-			getPrimKey(), ActionKeys.VIEW);
+			String.valueOf(group.getGroupId()), ActionKeys.VIEW);
 
 		RoleTestUtil.removeResourcePermission(
 			getRoleName(), getResourceName(),

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 13.0.1
+Bundle-Version: 13.1.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -792,20 +792,6 @@ public class DataGuardTestRuleUtil {
 	private static class RecordingSessionWrapper extends SessionWrapper {
 
 		@Override
-		public void delete(Object object) throws ORMException {
-			super.delete(object);
-
-			BaseModel<?> baseModel = (BaseModel<?>)object;
-
-			Map<Serializable, String> map = _records.get(
-				baseModel.getModelClassName());
-
-			if (map != null) {
-				map.remove(baseModel.getPrimaryKeyObj());
-			}
-		}
-
-		@Override
 		public Serializable save(Object object) throws ORMException {
 			_record(object);
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -21,24 +21,29 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.ClassLoaderBeanHandler;
 import com.liferay.portal.kernel.dao.orm.ORMException;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.SessionCustomizer;
 import com.liferay.portal.kernel.dao.orm.SessionFactory;
 import com.liferay.portal.kernel.dao.orm.SessionWrapper;
+import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.ResourcePermissionTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
@@ -54,6 +59,7 @@ import java.lang.reflect.Method;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -94,6 +100,9 @@ public class DataGuardTestRuleUtil {
 		_autoDeleteAndAssert(
 			testClassName, dataBag._dataMap, dataBag._portlets,
 			dataBag._records, autoDelete);
+
+		_orphanResourcePermissionDetection(
+			testClassName, dataBag._dataMap, dataBag._records);
 	}
 
 	public static void afterMethod(DataBag dataBag, String testClassName)
@@ -109,6 +118,9 @@ public class DataGuardTestRuleUtil {
 		_autoDeleteAndAssert(
 			testClassName, dataBag._dataMap, dataBag._portlets,
 			dataBag._records, autoDelete);
+
+		_orphanResourcePermissionDetection(
+			testClassName, dataBag._dataMap, dataBag._records);
 	}
 
 	public static DataBag beforeClass() {
@@ -180,6 +192,10 @@ public class DataGuardTestRuleUtil {
 		for (Map.Entry<String, List<BaseModel<?>>> entry : dataMap.entrySet()) {
 			String className = entry.getKey();
 
+			if (className.equals(ResourcePermission.class.getName())) {
+				continue;
+			}
+
 			List<BaseModel<?>> currentBaseModels = entry.getValue();
 
 			List<BaseModel<?>> previsoutBaseModels = previousDataMap.remove(
@@ -246,6 +262,10 @@ public class DataGuardTestRuleUtil {
 					dataMap.entrySet()) {
 
 				String className = entry.getKey();
+
+				if (className.equals(ResourcePermission.class.getName())) {
+					continue;
+				}
 
 				PersistedModelLocalService persistedModelLocalService =
 					persistedModelLocalServices.get(className);
@@ -489,6 +509,111 @@ public class DataGuardTestRuleUtil {
 		};
 	}
 
+	private static boolean _isOrphanResourcePermission(
+			Map<String, PersistedModelLocalService> persistedModelLocalServices,
+			ResourcePermission resourcePermission)
+		throws PortalException {
+
+		if (resourcePermission.getPrimKeyId() == 0) {
+			return false;
+		}
+
+		PersistedModelLocalService persistedModelLocalService =
+			persistedModelLocalServices.get(resourcePermission.getName());
+
+		if (persistedModelLocalService == null) {
+			return false;
+		}
+
+		try {
+			persistedModelLocalService.getPersistedModel(
+				resourcePermission.getPrimKeyId());
+
+			return false;
+		}
+		catch (NoSuchModelException noSuchModelException) {
+		}
+
+		return true;
+	}
+
+	private static void _orphanResourcePermissionDetection(
+			String testClassName,
+			Map<String, List<BaseModel<?>>> previousDataMap,
+			Map<String, Map<Serializable, String>> records)
+		throws Throwable {
+
+		List<ResourcePermission> resourcePermissions =
+			ResourcePermissionLocalServiceUtil.getResourcePermissions(
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		List<ResourcePermission> createdResourcePermissions = new ArrayList<>(
+			resourcePermissions);
+
+		List<BaseModel<?>> previousResourcePermissions = previousDataMap.remove(
+			ResourcePermission.class.getName());
+
+		if (previousResourcePermissions != null) {
+			createdResourcePermissions.removeAll(previousResourcePermissions);
+		}
+
+		Map<String, PersistedModelLocalService> persistedModelLocalServices =
+			_getPersistedModelLocalServices();
+
+		List<ResourcePermission> orphanResourcePermissions = new ArrayList<>();
+
+		for (ResourcePermission resourcePermission :
+				createdResourcePermissions) {
+
+			ResourcePermissionLocalServiceUtil.deleteResourcePermission(
+				resourcePermission);
+
+			if (_isOrphanResourcePermission(
+					persistedModelLocalServices, resourcePermission)) {
+
+				orphanResourcePermissions.add(resourcePermission);
+			}
+		}
+
+		if (orphanResourcePermissions.isEmpty()) {
+			return;
+		}
+
+		StringBundler sb = new StringBundler();
+
+		sb.append(testClassName);
+		sb.append(" caused orphan ResourcePermission with data : [\n");
+
+		Map<Serializable, String> resourcePermissionRecords =
+			records.getOrDefault(
+				ResourcePermission.class.getName(), Collections.emptyMap());
+
+		for (ResourcePermission resourcePermission :
+				orphanResourcePermissions) {
+
+			sb.append(StringPool.TAB);
+			sb.append(resourcePermission);
+
+			String backtraceInfo = resourcePermissionRecords.get(
+				resourcePermission.getPrimaryKeyObj());
+
+			if (backtraceInfo == null) {
+				sb.append(" with no backtrace info,\n");
+			}
+			else {
+				sb.append(" with backtrace info,\n");
+				sb.append(StringPool.TAB);
+				sb.append(StringPool.TAB);
+				sb.append(backtraceInfo);
+				sb.append(",\n");
+			}
+		}
+
+		sb.setStringAt("\n]\n", sb.index() - 1);
+
+		Assert.assertTrue(sb.toString(), sb.index() == 0);
+	}
+
 	private static Closeable _removeSessionFactoryVerifier(
 		BasePersistence<?> basePersistence) {
 
@@ -521,6 +646,8 @@ public class DataGuardTestRuleUtil {
 			PersistedModelLocalService persistedModelLocalService,
 			Class<?> modelClass, PersistedModel persistedModel)
 		throws Throwable {
+
+		ResourcePermissionTestUtil.deleteResourcePermissions(persistedModel);
 
 		Method deleteMethod = null;
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -30,12 +30,17 @@ import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
@@ -515,6 +520,28 @@ public class DataGuardTestRuleUtil {
 		throws PortalException {
 
 		if (resourcePermission.getPrimKeyId() == 0) {
+			return false;
+		}
+
+		if (resourcePermission.getScope() == ResourceConstants.SCOPE_COMPANY) {
+			Company company = CompanyLocalServiceUtil.fetchCompany(
+				resourcePermission.getPrimKeyId());
+
+			if (company == null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		if (resourcePermission.getScope() == ResourceConstants.SCOPE_GROUP) {
+			Group group = GroupLocalServiceUtil.fetchGroup(
+				resourcePermission.getPrimKeyId());
+
+			if (group == null) {
+				return true;
+			}
+
 			return false;
 		}
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -21,30 +21,22 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.ClassLoaderBeanHandler;
 import com.liferay.portal.kernel.dao.orm.ORMException;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.SessionCustomizer;
 import com.liferay.portal.kernel.dao.orm.SessionFactory;
 import com.liferay.portal.kernel.dao.orm.SessionWrapper;
-import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.BaseModel;
-import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.Portlet;
-import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
-import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
-import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -64,7 +56,6 @@ import java.lang.reflect.Method;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -105,9 +96,6 @@ public class DataGuardTestRuleUtil {
 		_autoDeleteAndAssert(
 			testClassName, dataBag._dataMap, dataBag._portlets,
 			dataBag._records, autoDelete);
-
-		_orphanResourcePermissionDetection(
-			testClassName, dataBag._dataMap, dataBag._records);
 	}
 
 	public static void afterMethod(DataBag dataBag, String testClassName)
@@ -123,9 +111,6 @@ public class DataGuardTestRuleUtil {
 		_autoDeleteAndAssert(
 			testClassName, dataBag._dataMap, dataBag._portlets,
 			dataBag._records, autoDelete);
-
-		_orphanResourcePermissionDetection(
-			testClassName, dataBag._dataMap, dataBag._records);
 	}
 
 	public static DataBag beforeClass() {
@@ -196,10 +181,6 @@ public class DataGuardTestRuleUtil {
 
 		for (Map.Entry<String, List<BaseModel<?>>> entry : dataMap.entrySet()) {
 			String className = entry.getKey();
-
-			if (className.equals(ResourcePermission.class.getName())) {
-				continue;
-			}
 
 			List<BaseModel<?>> currentBaseModels = entry.getValue();
 
@@ -512,133 +493,6 @@ public class DataGuardTestRuleUtil {
 
 			bundleContext.ungetService(serviceReference);
 		};
-	}
-
-	private static boolean _isOrphanResourcePermission(
-			Map<String, PersistedModelLocalService> persistedModelLocalServices,
-			ResourcePermission resourcePermission)
-		throws PortalException {
-
-		if (resourcePermission.getPrimKeyId() == 0) {
-			return false;
-		}
-
-		if (resourcePermission.getScope() == ResourceConstants.SCOPE_COMPANY) {
-			Company company = CompanyLocalServiceUtil.fetchCompany(
-				resourcePermission.getPrimKeyId());
-
-			if (company == null) {
-				return true;
-			}
-
-			return false;
-		}
-
-		if (resourcePermission.getScope() == ResourceConstants.SCOPE_GROUP) {
-			Group group = GroupLocalServiceUtil.fetchGroup(
-				resourcePermission.getPrimKeyId());
-
-			if (group == null) {
-				return true;
-			}
-
-			return false;
-		}
-
-		PersistedModelLocalService persistedModelLocalService =
-			persistedModelLocalServices.get(resourcePermission.getName());
-
-		if (persistedModelLocalService == null) {
-			return false;
-		}
-
-		try {
-			persistedModelLocalService.getPersistedModel(
-				resourcePermission.getPrimKeyId());
-
-			return false;
-		}
-		catch (NoSuchModelException noSuchModelException) {
-		}
-
-		return true;
-	}
-
-	private static void _orphanResourcePermissionDetection(
-			String testClassName,
-			Map<String, List<BaseModel<?>>> previousDataMap,
-			Map<String, Map<Serializable, String>> records)
-		throws Throwable {
-
-		List<ResourcePermission> resourcePermissions =
-			ResourcePermissionLocalServiceUtil.getResourcePermissions(
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-		List<ResourcePermission> createdResourcePermissions = new ArrayList<>(
-			resourcePermissions);
-
-		List<BaseModel<?>> previousResourcePermissions = previousDataMap.remove(
-			ResourcePermission.class.getName());
-
-		if (previousResourcePermissions != null) {
-			createdResourcePermissions.removeAll(previousResourcePermissions);
-		}
-
-		Map<String, PersistedModelLocalService> persistedModelLocalServices =
-			_getPersistedModelLocalServices();
-
-		List<ResourcePermission> orphanResourcePermissions = new ArrayList<>();
-
-		for (ResourcePermission resourcePermission :
-				createdResourcePermissions) {
-
-			ResourcePermissionLocalServiceUtil.deleteResourcePermission(
-				resourcePermission);
-
-			if (_isOrphanResourcePermission(
-					persistedModelLocalServices, resourcePermission)) {
-
-				orphanResourcePermissions.add(resourcePermission);
-			}
-		}
-
-		if (orphanResourcePermissions.isEmpty()) {
-			return;
-		}
-
-		StringBundler sb = new StringBundler();
-
-		sb.append(testClassName);
-		sb.append(" caused orphan ResourcePermission with data : [\n");
-
-		Map<Serializable, String> resourcePermissionRecords =
-			records.getOrDefault(
-				ResourcePermission.class.getName(), Collections.emptyMap());
-
-		for (ResourcePermission resourcePermission :
-				orphanResourcePermissions) {
-
-			sb.append(StringPool.TAB);
-			sb.append(resourcePermission);
-
-			String backtraceInfo = resourcePermissionRecords.get(
-				resourcePermission.getPrimaryKeyObj());
-
-			if (backtraceInfo == null) {
-				sb.append(" with no backtrace info,\n");
-			}
-			else {
-				sb.append(" with backtrace info,\n");
-				sb.append(StringPool.TAB);
-				sb.append(StringPool.TAB);
-				sb.append(backtraceInfo);
-				sb.append(",\n");
-			}
-		}
-
-		sb.setStringAt("\n]\n", sb.index() - 1);
-
-		Assert.assertTrue(sb.toString(), sb.index() == 0);
 	}
 
 	private static Closeable _removeSessionFactoryVerifier(

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -21,22 +21,30 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.ClassLoaderBeanHandler;
 import com.liferay.portal.kernel.dao.orm.ORMException;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.SessionCustomizer;
 import com.liferay.portal.kernel.dao.orm.SessionFactory;
 import com.liferay.portal.kernel.dao.orm.SessionWrapper;
+import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistryUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceWrapper;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -289,6 +297,31 @@ public class DataGuardTestRuleUtil {
 				break;
 			}
 		}
+
+		List<ResourcePermission> resourcePermissions =
+			ResourcePermissionLocalServiceUtil.getResourcePermissions(
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		List<ResourcePermission> createdResourcePermissions = new ArrayList<>(
+			resourcePermissions);
+
+		List<BaseModel<?>> previousResourcePermissions = previousDataMap.get(
+			ResourcePermission.class.getName());
+
+		if (previousResourcePermissions != null) {
+			createdResourcePermissions.removeAll(previousResourcePermissions);
+		}
+
+		for (ResourcePermission resourcePermission :
+				createdResourcePermissions) {
+
+			if (!_isOrphanResourcePermission(
+					persistedModelLocalServices, resourcePermission)) {
+
+				ResourcePermissionLocalServiceUtil.deleteResourcePermission(
+					resourcePermission);
+			}
+		}
 	}
 
 	private static Map<String, List<BaseModel<?>>> _captureDataMap() {
@@ -493,6 +526,56 @@ public class DataGuardTestRuleUtil {
 
 			bundleContext.ungetService(serviceReference);
 		};
+	}
+
+	private static boolean _isOrphanResourcePermission(
+			Map<String, PersistedModelLocalService> persistedModelLocalServices,
+			ResourcePermission resourcePermission)
+		throws PortalException {
+
+		if (resourcePermission.getPrimKeyId() == 0) {
+			return false;
+		}
+
+		if (resourcePermission.getScope() == ResourceConstants.SCOPE_COMPANY) {
+			Company company = CompanyLocalServiceUtil.fetchCompany(
+				resourcePermission.getPrimKeyId());
+
+			if (company == null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		if (resourcePermission.getScope() == ResourceConstants.SCOPE_GROUP) {
+			Group group = GroupLocalServiceUtil.fetchGroup(
+				resourcePermission.getPrimKeyId());
+
+			if (group == null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		PersistedModelLocalService persistedModelLocalService =
+			persistedModelLocalServices.get(resourcePermission.getName());
+
+		if (persistedModelLocalService == null) {
+			return false;
+		}
+
+		try {
+			persistedModelLocalService.getPersistedModel(
+				resourcePermission.getPrimKeyId());
+
+			return false;
+		}
+		catch (NoSuchModelException noSuchModelException) {
+		}
+
+		return true;
 	}
 
 	private static Closeable _removeSessionFactoryVerifier(

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DeleteAfterTestRunMethodTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DeleteAfterTestRunMethodTestRule.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistryUtil;
+import com.liferay.portal.kernel.test.util.ResourcePermissionTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.lang.reflect.Field;
@@ -246,6 +247,9 @@ public class DeleteAfterTestRunMethodTestRule extends MethodTestRule<Void> {
 
 					persistedModelLocalService.deletePersistedModel(
 						persistedModel);
+
+					ResourcePermissionTestUtil.deleteResourcePermissions(
+						persistedModel);
 				}
 			}
 			else if (Collection.class.isAssignableFrom(objectClass)) {
@@ -255,10 +259,16 @@ public class DeleteAfterTestRunMethodTestRule extends MethodTestRule<Void> {
 				for (PersistedModel persistedModel : collection) {
 					persistedModelLocalService.deletePersistedModel(
 						persistedModel);
+
+					ResourcePermissionTestUtil.deleteResourcePermissions(
+						persistedModel);
 				}
 			}
 			else {
 				persistedModelLocalService.deletePersistedModel(
+					(PersistedModel)object);
+
+				ResourcePermissionTestUtil.deleteResourcePermissions(
 					(PersistedModel)object);
 			}
 

--- a/portal-test/src/com/liferay/portal/kernel/test/util/ResourcePermissionTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/ResourcePermissionTestUtil.java
@@ -15,7 +15,12 @@
 package com.liferay.portal.kernel.test.util;
 
 import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.PersistedModel;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.ResourcedModel;
+import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
@@ -63,6 +68,36 @@ public class ResourcePermissionTestUtil {
 
 		return ResourcePermissionLocalServiceUtil.addResourcePermission(
 			resourcePermission);
+	}
+
+	public static void deleteResourcePermissions(PersistedModel persistedModel)
+		throws Exception {
+
+		if (!(persistedModel instanceof BaseModel) ||
+			!(persistedModel instanceof ShardedModel)) {
+
+			return;
+		}
+
+		BaseModel<?> baseModel = (BaseModel)persistedModel;
+
+		ShardedModel shardedModel = (ShardedModel)baseModel;
+
+		ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+			shardedModel.getCompanyId(), baseModel.getModelClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(baseModel.getPrimaryKeyObj()));
+
+		if (!(persistedModel instanceof ResourcedModel)) {
+			return;
+		}
+
+		ResourcedModel resourcedModel = (ResourcedModel)baseModel;
+
+		ResourcePermissionLocalServiceUtil.deleteResourcePermissions(
+			shardedModel.getCompanyId(), baseModel.getModelClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourcedModel.getResourcePrimKey()));
 	}
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/util/ResourcePermissionTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/ResourcePermissionTestUtil.java
@@ -15,14 +15,21 @@
 package com.liferay.portal.kernel.test.util;
 
 import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.ResourcePermissionTable;
 import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.util.List;
 
 /**
  * @author Alberto Chaparro
@@ -73,6 +80,34 @@ public class ResourcePermissionTestUtil {
 	public static void deleteResourcePermissions(PersistedModel persistedModel)
 		throws Exception {
 
+		if (persistedModel instanceof Company) {
+			Company company = (Company)persistedModel;
+
+			_deleteResourcePermissions(
+				company.getCompanyId(), ResourceConstants.SCOPE_COMPANY,
+				String.valueOf(company.getCompanyId()));
+
+			_deleteResourcePermissions(
+				company.getCompanyId(), ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(company.getCompanyId()));
+
+			return;
+		}
+
+		if (persistedModel instanceof Group) {
+			Group group = (Group)persistedModel;
+
+			_deleteResourcePermissions(
+				group.getCompanyId(), ResourceConstants.SCOPE_GROUP,
+				String.valueOf(group.getGroupId()));
+
+			_deleteResourcePermissions(
+				group.getCompanyId(), ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(group.getGroupId()));
+
+			return;
+		}
+
 		if (!(persistedModel instanceof BaseModel) ||
 			!(persistedModel instanceof ShardedModel)) {
 
@@ -98,6 +133,33 @@ public class ResourcePermissionTestUtil {
 			shardedModel.getCompanyId(), baseModel.getModelClassName(),
 			ResourceConstants.SCOPE_INDIVIDUAL,
 			String.valueOf(resourcedModel.getResourcePrimKey()));
+	}
+
+	private static void _deleteResourcePermissions(
+			long companyId, int scope, String primKey)
+		throws Exception {
+
+		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
+			ResourcePermissionTable.INSTANCE.resourcePermissionId
+		).from(
+			ResourcePermissionTable.INSTANCE
+		).where(
+			ResourcePermissionTable.INSTANCE.companyId.eq(
+				companyId
+			).and(
+				ResourcePermissionTable.INSTANCE.scope.eq(scope)
+			).and(
+				ResourcePermissionTable.INSTANCE.primKey.eq(primKey)
+			)
+		);
+
+		for (long resourcePermissionId :
+				ResourcePermissionLocalServiceUtil.<List<Long>>dslQuery(
+					dslQuery)) {
+
+			ResourcePermissionLocalServiceUtil.deleteResourcePermission(
+				resourcePermissionId);
+		}
 	}
 
 }

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0


### PR DESCRIPTION
- LPS-145396 Delete ResourcePermissions entries in DeleteAfterTestRunMethodTestRule to avoid false positives
- LPS-145396 New method to detect orphan ResourcePermission
- LPS-145396 Check existing company and group
- LPS-145396 Delete the resource permissions of the group and company scopes
- LPS-145396 When DataGuard is executed with method scope the objects deleted during the _autoDeleteLeftovers execution are removed from the _records map and after that we cannot display it in the Assert message. Reverts "LPS-138761 DataGuard: Remove the deleted objects from the _records map as we are not going to need it and we will save memory"
- LPS-145396 Fix false positives in tests, replacing *LocalServiceBaseImpl delete method calls with *LocalServiceImpl ones
- LPS-145936 Is this enough for checking orphan ResourcePermission which are left over even after auto delete (auto delete still skips ResourcePermission)?
- LPS-145396 In the _autoDeleteLeftovers method, delete the ResourcePermission that weren't deleted because they are linked to a object that wasn't created during the test execution
