### PR TITLE
LPS-166969_2

### DIFF
--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/upgrade/v1_0_0/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/upgrade/v1_0_0/test/UpgradePortletPreferencesTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.xml.SAXReader;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -53,7 +54,6 @@ import java.text.DateFormat;
 
 import java.util.Date;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.portlet.PortletPreferences;
 
@@ -66,7 +66,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -407,24 +406,8 @@ public class UpgradePortletPreferencesTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			UpgradePortletPreferencesTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Bundle assetPublisherWebBundle = null;
-
-		for (Bundle curBundle : bundleContext.getBundles()) {
-			if (Objects.equals(
-					curBundle.getSymbolicName(),
-					"com.liferay.asset.publisher.web")) {
-
-				assetPublisherWebBundle = curBundle;
-
-				break;
-			}
-		}
-
-		Assert.assertNotNull(
-			"Unable to find asset-publisher-web bundle",
-			assetPublisherWebBundle);
+		Bundle assetPublisherWebBundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.asset.publisher.web");
 
 		Class<?> clazz = assetPublisherWebBundle.loadClass(
 			"com.liferay.asset.publisher.web.internal.upgrade.v1_0_0." +

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/messaging/helper/test/AssetEntriesCheckerHelperTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/messaging/helper/test/AssetEntriesCheckerHelperTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -59,7 +60,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -184,24 +184,8 @@ public class AssetEntriesCheckerHelperTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			AssetEntriesCheckerHelperTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Bundle assetPublisherWebBundle = null;
-
-		for (Bundle curBundle : bundleContext.getBundles()) {
-			if (Objects.equals(
-					curBundle.getSymbolicName(),
-					"com.liferay.asset.publisher.web")) {
-
-				assetPublisherWebBundle = curBundle;
-
-				break;
-			}
-		}
-
-		Assert.assertNotNull(
-			"Unable to find asset-publisher-web bundle",
-			assetPublisherWebBundle);
+		Bundle assetPublisherWebBundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.asset.publisher.web");
 
 		Class<?> clazz = assetPublisherWebBundle.loadClass(
 			"com.liferay.asset.publisher.web.internal.messaging.helper." +

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/attachments/test/BlogsEntryImageSelectorHelperTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/attachments/test/BlogsEntryImageSelectorHelperTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.InputStream;
@@ -47,7 +48,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -66,17 +66,8 @@ public class BlogsEntryImageSelectorHelperTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			BlogsEntryAttachmentFileEntryHelperTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		for (Bundle installedBundle : bundleContext.getBundles()) {
-			String symbolicName = installedBundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.blogs.web")) {
-				bundle = installedBundle;
-
-				break;
-			}
-		}
+		bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.blogs.web");
 
 		Class<?> clazz = bundle.loadClass(
 			"com.liferay.blogs.web.internal.helper." +

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
@@ -72,6 +72,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.test.mail.MailServiceTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.SynchronousMailTestRule;
@@ -96,7 +97,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -117,17 +117,8 @@ public class BlogsEntryLocalServiceTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			BlogsEntryAttachmentFileEntryHelperTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		for (Bundle installedBundle : bundleContext.getBundles()) {
-			String symbolicName = installedBundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.blogs.web")) {
-				bundle = installedBundle;
-
-				break;
-			}
-		}
+		bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.blogs.web");
 
 		Class<?> clazz = bundle.loadClass(
 			"com.liferay.blogs.web.internal.util.BlogsUtil");

--- a/modules/apps/calendar/calendar-test-util/build.gradle
+++ b/modules/apps/calendar/calendar-test-util/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.test", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"

--- a/modules/apps/calendar/calendar-test-util/src/main/java/com/liferay/calendar/test/util/UpgradeDatabaseTestHelperImpl.java
+++ b/modules/apps/calendar/calendar-test-util/src/main/java/com/liferay/calendar/test/util/UpgradeDatabaseTestHelperImpl.java
@@ -15,12 +15,12 @@
 package com.liferay.calendar.test.util;
 
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.module.util.BundleUtil;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.wiring.BundleWiring;
 
@@ -72,19 +72,8 @@ public class UpgradeDatabaseTestHelperImpl
 		Bundle testBundle = FrameworkUtil.getBundle(
 			UpgradeDatabaseTestHelperImpl.class);
 
-		BundleContext bundleContext = testBundle.getBundleContext();
-
-		Bundle calendarServiceBundle = null;
-
-		for (Bundle bundle : bundleContext.getBundles()) {
-			String symbolicName = bundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.calendar.service")) {
-				calendarServiceBundle = bundle;
-
-				break;
-			}
-		}
+		Bundle calendarServiceBundle = BundleUtil.getBundle(
+			testBundle.getBundleContext(), "com.liferay.calendar.service");
 
 		BundleWiring bundleWiring = calendarServiceBundle.adapt(
 			BundleWiring.class);

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/util/test/CalendarUtilTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/util/test/CalendarUtilTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.TimeZoneUtil;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.SynchronousMailTestRule;
@@ -63,7 +64,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.wiring.BundleWiring;
 
@@ -84,19 +84,8 @@ public class CalendarUtilTest {
 	public static void setUpClass() throws Exception {
 		Bundle testBundle = FrameworkUtil.getBundle(CalendarUtilTest.class);
 
-		BundleContext bundleContext = testBundle.getBundleContext();
-
-		Bundle calendarWebBundle = null;
-
-		for (Bundle bundle : bundleContext.getBundles()) {
-			String symbolicName = bundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.calendar.web")) {
-				calendarWebBundle = bundle;
-
-				break;
-			}
-		}
+		Bundle calendarWebBundle = BundleUtil.getBundle(
+			testBundle.getBundleContext(), "com.liferay.calendar.web");
 
 		BundleWiring bundleWiring = calendarWebBundle.adapt(BundleWiring.class);
 

--- a/modules/apps/configuration-admin/configuration-admin-test/build.gradle
+++ b/modules/apps/configuration-admin/configuration-admin-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.metatype", version: "1.3.0"
 	testIntegrationCompile project(":apps:configuration-admin:configuration-admin-api")

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/search/test/ConfigurationModelIndexerTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/search/test/ConfigurationModelIndexerTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -76,8 +77,8 @@ public class ConfigurationModelIndexerTest {
 
 		_bundleContext = _bundle.getBundleContext();
 
-		Bundle configAdminWebBundle = _getBundle(
-			"com.liferay.configuration.admin.web");
+		Bundle configAdminWebBundle = BundleUtil.getBundle(
+			_bundleContext, "com.liferay.configuration.admin.web");
 
 		Class<?> configurationModelClass = configAdminWebBundle.loadClass(
 			"com.liferay.configuration.admin.web.internal.model." +
@@ -188,18 +189,6 @@ public class ConfigurationModelIndexerTest {
 		Hits hits = _indexer.search(searchContext);
 
 		Assert.assertEquals(hits.toString(), 1, hits.getLength());
-	}
-
-	private Bundle _getBundle(String bundleSymbolicName) {
-		Bundle[] bundles = _bundleContext.getBundles();
-
-		for (Bundle bundle : bundles) {
-			if (bundleSymbolicName.equals(bundle.getSymbolicName())) {
-				return bundle;
-			}
-		}
-
-		return null;
 	}
 
 	private static final String _PID = RandomTestUtil.randomString(50);

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/util/test/ConfigurationDDMFormDeclarationUtilTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/util/test/ConfigurationDDMFormDeclarationUtilTest.java
@@ -19,10 +19,9 @@ import com.liferay.configuration.admin.definition.ConfigurationDDMFormDeclaratio
 import com.liferay.osgi.util.service.OSGiServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.module.util.BundleUtil;
 
 import java.lang.reflect.Method;
-
-import java.util.Objects;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -61,23 +60,8 @@ public class ConfigurationDDMFormDeclarationUtilTest {
 		_serviceRegistration = _registerConfigurationDDMFormDeclaration(
 			configurationDDMFormDeclaration, _configuration.getPid());
 
-		Bundle bundle = null;
-
-		for (Bundle installedBundle : _bundleContext.getBundles()) {
-			if (Objects.equals(
-					installedBundle.getSymbolicName(),
-					"com.liferay.configuration.admin.web")) {
-
-				bundle = installedBundle;
-
-				break;
-			}
-		}
-
-		if (bundle == null) {
-			throw new IllegalStateException(
-				"com.liferay.configuration.admin.web bundle not found");
-		}
+		Bundle bundle = BundleUtil.getBundle(
+			_bundleContext, "com.liferay.configuration.admin.web");
 
 		Class<?> clazz = bundle.loadClass(
 			"com.liferay.configuration.admin.web.internal.util." +

--- a/modules/apps/journal/journal-test-util/build.gradle
+++ b/modules/apps/journal/journal-test-util/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.test", version: "default"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -60,6 +60,7 @@ import com.liferay.portal.kernel.xml.Node;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portal.kernel.xml.UnsecureSAXReaderUtil;
 import com.liferay.portal.kernel.xml.XPath;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.rss.util.RSSUtil;
 
 import java.lang.reflect.Method;
@@ -73,7 +74,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.wiring.BundleWiring;
 
@@ -1171,24 +1171,8 @@ public class JournalTestUtil {
 	static {
 		Bundle testBundle = FrameworkUtil.getBundle(JournalTestUtil.class);
 
-		BundleContext bundleContext = testBundle.getBundleContext();
-
-		Bundle journalServiceBundle = null;
-
-		for (Bundle bundle : bundleContext.getBundles()) {
-			String symbolicName = bundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.journal.service")) {
-				journalServiceBundle = bundle;
-
-				break;
-			}
-		}
-
-		if (journalServiceBundle == null) {
-			throw new ExceptionInInitializerError(
-				"Unable to find com.liferay.journal.service bundle");
-		}
+		Bundle journalServiceBundle = BundleUtil.getBundle(
+			testBundle.getBundleContext(), "com.liferay.journal.service");
 
 		BundleWiring bundleWiring = journalServiceBundle.adapt(
 			BundleWiring.class);

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/importer/util/test/KBArticleMarkdownConverterTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/importer/util/test/KBArticleMarkdownConverterTest.java
@@ -18,6 +18,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -35,7 +36,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -54,17 +54,8 @@ public class KBArticleMarkdownConverterTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			KBArticleMarkdownConverterTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		for (Bundle installedBundle : bundleContext.getBundles()) {
-			String symbolicName = installedBundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.knowledge.base.service")) {
-				bundle = installedBundle;
-
-				break;
-			}
-		}
+		bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.knowledge.base.service");
 
 		Class<?> clazz = bundle.loadClass(
 			"com.liferay.knowledge.base.internal.importer.util." +

--- a/modules/apps/portal-configuration/portal-configuration-extender-test/build.gradle
+++ b/modules/apps/portal-configuration/portal-configuration-extender-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	testIntegrationCompile group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/portal-configuration/portal-configuration-extender-test/src/testIntegration/java/com/liferay/portal/configuration/extender/internal/test/ConfiguratorExtenderTest.java
+++ b/modules/apps/portal-configuration/portal-configuration-extender-test/src/testIntegration/java/com/liferay/portal/configuration/extender/internal/test/ConfiguratorExtenderTest.java
@@ -21,6 +21,7 @@ import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -68,21 +69,9 @@ public class ConfiguratorExtenderTest {
 	public void setUp() {
 		Bundle bundle = FrameworkUtil.getBundle(ConfiguratorExtenderTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		String symbolicName = "com.liferay.portal.configuration.extender";
-
-		for (Bundle curBundle : bundleContext.getBundles()) {
-			if (symbolicName.equals(curBundle.getSymbolicName())) {
-				_bundle = curBundle;
-
-				break;
-			}
-		}
-
-		Assert.assertNotNull(
-			"Unable to find bundle with symbolic name: " + symbolicName,
-			_bundle);
+		_bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(),
+			"com.liferay.portal.configuration.extender");
 	}
 
 	@After

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/IndexerRequestBufferTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/IndexerRequestBufferTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.test.util.search.JournalArticleBlueprint;
+import com.liferay.journal.test.util.search.JournalArticleContent;
+import com.liferay.journal.test.util.search.JournalArticleSearchFixture;
+import com.liferay.journal.test.util.search.JournalArticleTitle;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.search.test.util.SearchTestRule;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Jorge Díaz
+ */
+@RunWith(Arquillian.class)
+public class IndexerRequestBufferTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		TransactionConfig.Builder builder = new TransactionConfig.Builder();
+
+		builder.setPropagation(Propagation.REQUIRED);
+		builder.setRollbackForClasses(Exception.class);
+
+		_transactionConfig = builder.build();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_journalArticleSearchFixture = new JournalArticleSearchFixture(
+			_journalArticleLocalService);
+
+		_journalArticleSearchFixture.setUp();
+	}
+
+	@Test
+	public void testJournalArticleIndexedOnlyOnce() throws Throwable {
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				_addJournalArticle();
+
+				Assert.assertEquals(1, _getIndexerRequestBufferSize());
+
+				return null;
+			});
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	private void _addJournalArticle() throws Exception {
+		_journalArticleSearchFixture.addArticle(
+			new JournalArticleBlueprint() {
+				{
+					setGroupId(_group.getGroupId());
+					setJournalArticleContent(new JournalArticleContent());
+					setJournalArticleTitle(
+						new JournalArticleTitle() {
+							{
+								put(
+									LocaleUtil.US,
+									RandomTestUtil.randomString());
+							}
+						});
+				}
+			});
+	}
+
+	private Bundle _getBundle(String bundleName) throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		for (Bundle curBundle : bundleContext.getBundles()) {
+			if (Objects.equals(curBundle.getSymbolicName(), bundleName)) {
+				return curBundle;
+			}
+		}
+
+		return null;
+	}
+
+	private int _getIndexerRequestBufferSize() throws Exception {
+		Bundle bundle = _getBundle("com.liferay.portal.search");
+
+		Class<?> indexerRequestBufferClass = bundle.loadClass(
+			"com.liferay.portal.search.internal.buffer.IndexerRequestBuffer");
+
+		Object indexerRequestBuffer = ReflectionTestUtil.invoke(
+			indexerRequestBufferClass, "get", new Class<?>[0]);
+
+		return (int)ReflectionTestUtil.invoke(
+			indexerRequestBuffer, "size", new Class<?>[0]);
+	}
+
+	@Inject
+	private static JournalArticleLocalService _journalArticleLocalService;
+
+	private static TransactionConfig _transactionConfig;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private JournalArticleSearchFixture _journalArticleSearchFixture;
+
+}

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/IndexerRequestBufferTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/IndexerRequestBufferTest.java
@@ -30,11 +30,10 @@ import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-
-import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -45,7 +44,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -113,22 +111,11 @@ public class IndexerRequestBufferTest {
 			});
 	}
 
-	private Bundle _getBundle(String bundleName) throws Exception {
+	private int _getIndexerRequestBufferSize() throws Exception {
 		Bundle bundle = FrameworkUtil.getBundle(getClass());
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		for (Bundle curBundle : bundleContext.getBundles()) {
-			if (Objects.equals(curBundle.getSymbolicName(), bundleName)) {
-				return curBundle;
-			}
-		}
-
-		return null;
-	}
-
-	private int _getIndexerRequestBufferSize() throws Exception {
-		Bundle bundle = _getBundle("com.liferay.portal.search");
+		bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.portal.search");
 
 		Class<?> indexerRequestBufferClass = bundle.loadClass(
 			"com.liferay.portal.search.internal.buffer.IndexerRequestBuffer");

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/IndexerRegistryImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerPostProcessor;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.dummy.DummyIndexer;
+import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.search.configuration.IndexerRegistryConfiguration;
@@ -338,8 +339,8 @@ public class IndexerRegistryImpl implements IndexerRegistry {
 
 			BufferedIndexerInvocationHandler bufferedIndexerInvocationHandler =
 				new BufferedIndexerInvocationHandler(
-					indexer, _indexStatusManager,
-					_indexerRegistryConfiguration);
+					indexer, _indexStatusManager, _indexerRegistryConfiguration,
+					_persistedModelLocalServiceRegistry);
 
 			if (_indexerRequestBufferOverflowHandler == null) {
 				bufferedIndexerInvocationHandler.
@@ -386,6 +387,10 @@ public class IndexerRegistryImpl implements IndexerRegistry {
 
 	@Reference
 	private IndexStatusManager _indexStatusManager;
+
+	@Reference
+	private PersistedModelLocalServiceRegistry
+		_persistedModelLocalServiceRegistry;
 
 	private final Map<String, Indexer<? extends Object>> _proxiedIndexers =
 		new ConcurrentHashMap<>();

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.search.internal.buffer;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
@@ -138,21 +137,18 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 					getPersistedModelLocalService(className);
 
 			try {
-				Object obj = persistedModelLocalService.getPersistedModel(
+				Object object = persistedModelLocalService.getPersistedModel(
 					classPK);
 
-				if (obj instanceof ResourcedModel) {
-					ResourcedModel resourcedModel = (ResourcedModel)obj;
+				if (object instanceof ResourcedModel) {
+					ResourcedModel resourcedModel = (ResourcedModel)object;
 
 					classPK = resourcedModel.getResourcePrimKey();
 				}
 			}
 			catch (Exception exception) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						StringBundler.concat(
-							"Unable to get resource primary key for class ",
-							className, " with primary key ", classPK));
+				if (_log.isTraceEnabled()) {
+					_log.trace(exception);
 				}
 			}
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/buffer/BufferedIndexerInvocationHandler.java
@@ -14,13 +14,17 @@
 
 package com.liferay.portal.search.internal.buffer;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ClassedModel;
+import com.liferay.portal.kernel.model.ResourcedModel;
 import com.liferay.portal.kernel.search.Bufferable;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.search.configuration.IndexerRegistryConfiguration;
 import com.liferay.portal.search.index.IndexStatusManager;
@@ -40,11 +44,14 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 
 	public BufferedIndexerInvocationHandler(
 		Indexer<?> indexer, IndexStatusManager indexStatusManager,
-		IndexerRegistryConfiguration indexerRegistryConfiguration) {
+		IndexerRegistryConfiguration indexerRegistryConfiguration,
+		PersistedModelLocalServiceRegistry persistedModelLocalServiceRegistry) {
 
 		_indexer = indexer;
 		_indexStatusManager = indexStatusManager;
 		_indexerRegistryConfiguration = indexerRegistryConfiguration;
+		_persistedModelLocalServiceRegistry =
+			persistedModelLocalServiceRegistry;
 	}
 
 	@Override
@@ -103,6 +110,12 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 
 			Long classPK = (Long)classedModel.getPrimaryKeyObj();
 
+			if (args[0] instanceof ResourcedModel) {
+				ResourcedModel resourcedModel = (ResourcedModel)args[0];
+
+				classPK = resourcedModel.getResourcePrimKey();
+			}
+
 			bufferRequest(
 				methodKey, classedModel.getModelClassName(), classPK,
 				indexerRequestBuffer);
@@ -119,6 +132,29 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 
 			String className = (String)args[0];
 			Long classPK = (Long)args[1];
+
+			PersistedModelLocalService persistedModelLocalService =
+				_persistedModelLocalServiceRegistry.
+					getPersistedModelLocalService(className);
+
+			try {
+				Object obj = persistedModelLocalService.getPersistedModel(
+					classPK);
+
+				if (obj instanceof ResourcedModel) {
+					ResourcedModel resourcedModel = (ResourcedModel)obj;
+
+					classPK = resourcedModel.getResourcePrimKey();
+				}
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Unable to get resource primary key for class ",
+							className, " with primary key ", classPK));
+				}
+			}
 
 			bufferRequest(methodKey, className, classPK, indexerRequestBuffer);
 		}
@@ -219,5 +255,7 @@ public class BufferedIndexerInvocationHandler implements InvocationHandler {
 	private volatile IndexerRequestBufferOverflowHandler
 		_indexerRequestBufferOverflowHandler;
 	private final IndexStatusManager _indexStatusManager;
+	private final PersistedModelLocalServiceRegistry
+		_persistedModelLocalServiceRegistry;
 
 }

--- a/modules/apps/portal/portal-aop-test/src/testIntegration/java/com/liferay/portal/aop/test/AopServiceManagerConcurrencyTest.java
+++ b/modules/apps/portal/portal-aop-test/src/testIntegration/java/com/liferay/portal/aop/test/AopServiceManagerConcurrencyTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.spring.transaction.TransactionAttributeAdapter;
 import com.liferay.portal.spring.transaction.TransactionHandler;
 import com.liferay.portal.spring.transaction.TransactionStatusAdapter;
@@ -74,15 +75,8 @@ public class AopServiceManagerConcurrencyTest {
 		_executorService = Executors.newFixedThreadPool(
 			runtime.availableProcessors());
 
-		for (Bundle currentBundle : _bundleContext.getBundles()) {
-			String symbolicName = currentBundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.portal.aop.impl")) {
-				_aopImplBundle = currentBundle;
-
-				break;
-			}
-		}
+		_aopImplBundle = BundleUtil.getBundle(
+			_bundleContext, "com.liferay.portal.aop.impl");
 
 		Assert.assertNotNull(_aopImplBundle);
 	}

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/build.gradle
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testCompile group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	testCompile project(":apps:static:portal-lpkg-deployer:portal-lpkg-deployer-test-util")

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/src/testIntegration/java/com/liferay/portal/bundle/blacklist/test/BundleBlacklistTest.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/src/testIntegration/java/com/liferay/portal/bundle/blacklist/test/BundleBlacklistTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.lpkg.deployer.test.util.LPKGTestUtil;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -151,7 +152,7 @@ public class BundleBlacklistTest {
 
 	@Test
 	public void testAddToAndRemoveFromBlacklist() throws Exception {
-		Bundle bundle = _findBundle(_SYMBOLIC_NAME);
+		Bundle bundle = BundleUtil.getBundle(_bundleContext, _SYMBOLIC_NAME);
 
 		Assert.assertEquals(Bundle.ACTIVE, bundle.getState());
 
@@ -179,7 +180,7 @@ public class BundleBlacklistTest {
 
 		_bundleBlacklistManager.removeFromBlacklistAndInstall(_SYMBOLIC_NAME);
 
-		bundle = _findBundle(_SYMBOLIC_NAME);
+		bundle = BundleUtil.getBundle(_bundleContext, _SYMBOLIC_NAME);
 
 		Assert.assertEquals(Bundle.ACTIVE, bundle.getState());
 
@@ -245,13 +246,15 @@ public class BundleBlacklistTest {
 
 		_updateConfiguration(properties);
 
-		warWrapperBundle = _findBundle(warWrapperBundle.getSymbolicName());
+		warWrapperBundle = BundleUtil.getBundle(
+			_bundleContext, warWrapperBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"WAR wrapper bundle not reinstalled", Bundle.ACTIVE,
 			warWrapperBundle.getState());
 
-		warBundle = _findBundle(warBundle.getSymbolicName());
+		warBundle = BundleUtil.getBundle(
+			_bundleContext, warBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"WAR bundle not reinstalled", Bundle.ACTIVE, warBundle.getState());
@@ -270,7 +273,8 @@ public class BundleBlacklistTest {
 
 		_updateConfiguration(properties);
 
-		warBundle = _findBundle(warBundle.getSymbolicName());
+		warBundle = BundleUtil.getBundle(
+			_bundleContext, warBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"WAR bundle not reinstalled", Bundle.ACTIVE, warBundle.getState());
@@ -289,7 +293,8 @@ public class BundleBlacklistTest {
 
 		_updateConfiguration(properties);
 
-		jarBundle = _findBundle(jarBundle.getSymbolicName());
+		jarBundle = BundleUtil.getBundle(
+			_bundleContext, jarBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"JAR bundle not reinstalled", Bundle.ACTIVE, jarBundle.getState());
@@ -319,37 +324,30 @@ public class BundleBlacklistTest {
 
 		_updateConfiguration(properties);
 
-		lpkgBundle = _findBundle(lpkgBundle.getSymbolicName());
+		lpkgBundle = BundleUtil.getBundle(
+			_bundleContext, lpkgBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"LPKG not reinstalled", Bundle.ACTIVE, lpkgBundle.getState());
 
-		jarBundle = _findBundle(jarBundle.getSymbolicName());
+		jarBundle = BundleUtil.getBundle(
+			_bundleContext, jarBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"JAR bundle not reinstalled", Bundle.ACTIVE, jarBundle.getState());
 
-		warWrapperBundle = _findBundle(warWrapperBundle.getSymbolicName());
+		warWrapperBundle = BundleUtil.getBundle(
+			_bundleContext, warWrapperBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"WAR wrapper bundle not reinstalled", Bundle.ACTIVE,
 			warWrapperBundle.getState());
 
-		warBundle = _findBundle(warBundle.getSymbolicName());
+		warBundle = BundleUtil.getBundle(
+			_bundleContext, warBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"WAR bundle not reinstalled", Bundle.ACTIVE, warBundle.getState());
-	}
-
-	private Bundle _findBundle(String symbolicName) {
-		for (Bundle bundle : _bundleContext.getBundles()) {
-			if (symbolicName.equals(bundle.getSymbolicName())) {
-				return bundle;
-			}
-		}
-
-		throw new IllegalArgumentException(
-			"No bundle installed with symbolic name " + symbolicName);
 	}
 
 	private void _updateConfiguration(Dictionary<String, Object> dictionary)

--- a/modules/apps/static/portal-file-install/portal-file-install-test/src/testIntegration/java/com/liferay/portal/file/install/deploy/test/FileInstallDeployTest.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-test/src/testIntegration/java/com/liferay/portal/file/install/deploy/test/FileInstallDeployTest.java
@@ -19,6 +19,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -222,7 +223,8 @@ public class FileInstallDeployTest {
 
 			installCountDownLatch.await();
 
-			bundle = _getBundle(_TEST_JAR_SYMBOLIC_NAME);
+			bundle = BundleUtil.getBundle(
+				_bundleContext, _TEST_JAR_SYMBOLIC_NAME);
 
 			Assert.assertNotNull(bundle);
 
@@ -316,7 +318,8 @@ public class FileInstallDeployTest {
 
 			installCountDownLatch.await();
 
-			Bundle bundle = _getBundle(_TEST_JAR_SYMBOLIC_NAME);
+			Bundle bundle = BundleUtil.getBundle(
+				_bundleContext, _TEST_JAR_SYMBOLIC_NAME);
 
 			Assert.assertEquals(Bundle.ACTIVE, bundle.getState());
 
@@ -330,7 +333,8 @@ public class FileInstallDeployTest {
 
 			fragmentInstallCountDownLatch.await();
 
-			Bundle fragmentBundle = _getBundle(testFragmentSymbolicName);
+			Bundle fragmentBundle = BundleUtil.getBundle(
+				_bundleContext, testFragmentSymbolicName);
 
 			Assert.assertEquals(Bundle.RESOLVED, fragmentBundle.getState());
 
@@ -418,7 +422,8 @@ public class FileInstallDeployTest {
 
 			installCountDownLatch.await();
 
-			Bundle bundle = _getBundle(_TEST_JAR_SYMBOLIC_NAME);
+			Bundle bundle = BundleUtil.getBundle(
+				_bundleContext, _TEST_JAR_SYMBOLIC_NAME);
 
 			Assert.assertEquals(Bundle.ACTIVE, bundle.getState());
 
@@ -439,8 +444,8 @@ public class FileInstallDeployTest {
 
 			optionalProviderInstallCountDownLatch.await();
 
-			Bundle optionalProviderBundle = _getBundle(
-				testOptionalProviderSymbolicName);
+			Bundle optionalProviderBundle = BundleUtil.getBundle(
+				_bundleContext, testOptionalProviderSymbolicName);
 
 			Assert.assertEquals(
 				Bundle.ACTIVE, optionalProviderBundle.getState());
@@ -469,16 +474,6 @@ public class FileInstallDeployTest {
 
 			_uninstall(testOptionalProviderSymbolicName, optionalProviderPath);
 		}
-	}
-
-	private Bundle _getBundle(String symbolicName) {
-		for (Bundle currentBundle : _bundleContext.getBundles()) {
-			if (Objects.equals(currentBundle.getSymbolicName(), symbolicName)) {
-				return currentBundle;
-			}
-		}
-
-		return null;
 	}
 
 	private void _uninstall(String symbolicName, Path path) throws Exception {

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/persistence/test/LPKGPersistenceStartBundleTest.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/persistence/test/LPKGPersistenceStartBundleTest.java
@@ -15,13 +15,13 @@
 package com.liferay.portal.lpkg.deployer.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.module.util.BundleUtil;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.FrameworkUtil;
 
@@ -36,19 +36,8 @@ public class LPKGPersistenceStartBundleTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			LPKGPersistenceStartBundleTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Bundle lpkgPersistenceTestBundle = null;
-
-		for (Bundle testBundle : bundleContext.getBundles()) {
-			String symbolicName = testBundle.getSymbolicName();
-
-			if (symbolicName.equals("lpkg.persistence.test")) {
-				lpkgPersistenceTestBundle = testBundle;
-
-				break;
-			}
-		}
+		Bundle lpkgPersistenceTestBundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "lpkg.persistence.test");
 
 		Assert.assertNotNull(lpkgPersistenceTestBundle);
 

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/persistence/test/LPKGPersistenceStopBundleTest.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/persistence/test/LPKGPersistenceStopBundleTest.java
@@ -15,13 +15,13 @@
 package com.liferay.portal.lpkg.deployer.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.module.util.BundleUtil;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.FrameworkUtil;
 
@@ -36,21 +36,8 @@ public class LPKGPersistenceStopBundleTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			LPKGPersistenceStopBundleTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Bundle lpkgPersistenceTestBundle = null;
-
-		for (Bundle testBundle : bundleContext.getBundles()) {
-			String symbolicName = testBundle.getSymbolicName();
-
-			if (symbolicName.equals("lpkg.persistence.test")) {
-				lpkgPersistenceTestBundle = testBundle;
-
-				break;
-			}
-		}
-
-		Assert.assertNotNull(lpkgPersistenceTestBundle);
+		Bundle lpkgPersistenceTestBundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "lpkg.persistence.test");
 
 		Assert.assertEquals(
 			Bundle.ACTIVE, lpkgPersistenceTestBundle.getState());


### PR DESCRIPTION
- LPS-166969 New IndexerRequestBufferTest.testJournalArticleIndexedOnlyOnce() test to verify that only one IndexRequest is stored in the index request buffer when creating a JournalArticle
- LPS-166969 Use BundleUtil.getBundle method
- LPS-166969 Partial Revert "LPS-105011 portal-search: Add UIDFactory for UID Standardization"
- LPS-166969 SF
- LPS-166969 Apply BundleUtil.getBundle use everywhere
