### PR TITLE
LPS-168539 Use BundleUtil.getBundle method instead of repeating its code again and again

### DIFF
--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/upgrade/v1_0_0/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/upgrade/v1_0_0/test/UpgradePortletPreferencesTest.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.xml.SAXReader;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -53,7 +54,6 @@ import java.text.DateFormat;
 
 import java.util.Date;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.portlet.PortletPreferences;
 
@@ -66,7 +66,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -407,24 +406,8 @@ public class UpgradePortletPreferencesTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			UpgradePortletPreferencesTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Bundle assetPublisherWebBundle = null;
-
-		for (Bundle curBundle : bundleContext.getBundles()) {
-			if (Objects.equals(
-					curBundle.getSymbolicName(),
-					"com.liferay.asset.publisher.web")) {
-
-				assetPublisherWebBundle = curBundle;
-
-				break;
-			}
-		}
-
-		Assert.assertNotNull(
-			"Unable to find asset-publisher-web bundle",
-			assetPublisherWebBundle);
+		Bundle assetPublisherWebBundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.asset.publisher.web");
 
 		Class<?> clazz = assetPublisherWebBundle.loadClass(
 			"com.liferay.asset.publisher.web.internal.upgrade.v1_0_0." +

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/messaging/helper/test/AssetEntriesCheckerHelperTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/messaging/helper/test/AssetEntriesCheckerHelperTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -59,7 +60,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -184,24 +184,8 @@ public class AssetEntriesCheckerHelperTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			AssetEntriesCheckerHelperTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Bundle assetPublisherWebBundle = null;
-
-		for (Bundle curBundle : bundleContext.getBundles()) {
-			if (Objects.equals(
-					curBundle.getSymbolicName(),
-					"com.liferay.asset.publisher.web")) {
-
-				assetPublisherWebBundle = curBundle;
-
-				break;
-			}
-		}
-
-		Assert.assertNotNull(
-			"Unable to find asset-publisher-web bundle",
-			assetPublisherWebBundle);
+		Bundle assetPublisherWebBundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.asset.publisher.web");
 
 		Class<?> clazz = assetPublisherWebBundle.loadClass(
 			"com.liferay.asset.publisher.web.internal.messaging.helper." +

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/attachments/test/BlogsEntryImageSelectorHelperTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/attachments/test/BlogsEntryImageSelectorHelperTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.io.InputStream;
@@ -47,7 +48,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -66,17 +66,8 @@ public class BlogsEntryImageSelectorHelperTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			BlogsEntryAttachmentFileEntryHelperTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		for (Bundle installedBundle : bundleContext.getBundles()) {
-			String symbolicName = installedBundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.blogs.web")) {
-				bundle = installedBundle;
-
-				break;
-			}
-		}
+		bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.blogs.web");
 
 		Class<?> clazz = bundle.loadClass(
 			"com.liferay.blogs.web.internal.helper." +

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
@@ -71,6 +71,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.test.mail.MailServiceTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.SynchronousMailTestRule;
@@ -95,7 +96,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -116,17 +116,8 @@ public class BlogsEntryLocalServiceTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			BlogsEntryAttachmentFileEntryHelperTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		for (Bundle installedBundle : bundleContext.getBundles()) {
-			String symbolicName = installedBundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.blogs.web")) {
-				bundle = installedBundle;
-
-				break;
-			}
-		}
+		bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.blogs.web");
 
 		Class<?> clazz = bundle.loadClass(
 			"com.liferay.blogs.web.internal.util.BlogsUtil");

--- a/modules/apps/calendar/calendar-test-util/src/main/java/com/liferay/calendar/test/util/UpgradeDatabaseTestHelperImpl.java
+++ b/modules/apps/calendar/calendar-test-util/src/main/java/com/liferay/calendar/test/util/UpgradeDatabaseTestHelperImpl.java
@@ -15,12 +15,12 @@
 package com.liferay.calendar.test.util;
 
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 
 import java.sql.Connection;
 import java.sql.SQLException;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.wiring.BundleWiring;
 
@@ -72,19 +72,8 @@ public class UpgradeDatabaseTestHelperImpl
 		Bundle testBundle = FrameworkUtil.getBundle(
 			UpgradeDatabaseTestHelperImpl.class);
 
-		BundleContext bundleContext = testBundle.getBundleContext();
-
-		Bundle calendarServiceBundle = null;
-
-		for (Bundle bundle : bundleContext.getBundles()) {
-			String symbolicName = bundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.calendar.service")) {
-				calendarServiceBundle = bundle;
-
-				break;
-			}
-		}
+		Bundle calendarServiceBundle = BundleUtil.getBundle(
+			testBundle.getBundleContext(), "com.liferay.calendar.service");
 
 		BundleWiring bundleWiring = calendarServiceBundle.adapt(
 			BundleWiring.class);

--- a/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/util/test/CalendarUtilTest.java
+++ b/modules/apps/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/util/test/CalendarUtilTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.TimeZoneUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.SynchronousMailTestRule;
@@ -63,7 +64,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.wiring.BundleWiring;
 
@@ -84,19 +84,8 @@ public class CalendarUtilTest {
 	public static void setUpClass() throws Exception {
 		Bundle testBundle = FrameworkUtil.getBundle(CalendarUtilTest.class);
 
-		BundleContext bundleContext = testBundle.getBundleContext();
-
-		Bundle calendarWebBundle = null;
-
-		for (Bundle bundle : bundleContext.getBundles()) {
-			String symbolicName = bundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.calendar.web")) {
-				calendarWebBundle = bundle;
-
-				break;
-			}
-		}
+		Bundle calendarWebBundle = BundleUtil.getBundle(
+			testBundle.getBundleContext(), "com.liferay.calendar.web");
 
 		BundleWiring bundleWiring = calendarWebBundle.adapt(BundleWiring.class);
 

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/search/test/ConfigurationModelIndexerTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/search/test/ConfigurationModelIndexerTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -76,8 +77,8 @@ public class ConfigurationModelIndexerTest {
 
 		_bundleContext = _bundle.getBundleContext();
 
-		Bundle configAdminWebBundle = _getBundle(
-			"com.liferay.configuration.admin.web");
+		Bundle configAdminWebBundle = BundleUtil.getBundle(
+			_bundleContext, "com.liferay.configuration.admin.web");
 
 		Class<?> configurationModelClass = configAdminWebBundle.loadClass(
 			"com.liferay.configuration.admin.web.internal.model." +
@@ -188,18 +189,6 @@ public class ConfigurationModelIndexerTest {
 		Hits hits = _indexer.search(searchContext);
 
 		Assert.assertEquals(hits.toString(), 1, hits.getLength());
-	}
-
-	private Bundle _getBundle(String bundleSymbolicName) {
-		Bundle[] bundles = _bundleContext.getBundles();
-
-		for (Bundle bundle : bundles) {
-			if (bundleSymbolicName.equals(bundle.getSymbolicName())) {
-				return bundle;
-			}
-		}
-
-		return null;
 	}
 
 	private static final String _PID = RandomTestUtil.randomString(50);

--- a/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/util/test/ConfigurationDDMFormDeclarationUtilTest.java
+++ b/modules/apps/configuration-admin/configuration-admin-test/src/testIntegration/java/com/liferay/configuration/admin/internal/util/test/ConfigurationDDMFormDeclarationUtilTest.java
@@ -19,10 +19,9 @@ import com.liferay.configuration.admin.definition.ConfigurationDDMFormDeclaratio
 import com.liferay.osgi.util.service.OSGiServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 
 import java.lang.reflect.Method;
-
-import java.util.Objects;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -61,23 +60,8 @@ public class ConfigurationDDMFormDeclarationUtilTest {
 		_serviceRegistration = _registerConfigurationDDMFormDeclaration(
 			configurationDDMFormDeclaration, _configuration.getPid());
 
-		Bundle bundle = null;
-
-		for (Bundle installedBundle : _bundleContext.getBundles()) {
-			if (Objects.equals(
-					installedBundle.getSymbolicName(),
-					"com.liferay.configuration.admin.web")) {
-
-				bundle = installedBundle;
-
-				break;
-			}
-		}
-
-		if (bundle == null) {
-			throw new IllegalStateException(
-				"com.liferay.configuration.admin.web bundle not found");
-		}
+		Bundle bundle = BundleUtil.getBundle(
+			_bundleContext, "com.liferay.configuration.admin.web");
 
 		Class<?> clazz = bundle.loadClass(
 			"com.liferay.configuration.admin.web.internal.util." +

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -67,6 +67,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.rss.util.RSSUtil;
 
 import java.util.Calendar;
@@ -76,7 +77,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.wiring.BundleWiring;
 
@@ -1220,24 +1220,8 @@ public class JournalTestUtil {
 	static {
 		Bundle testBundle = FrameworkUtil.getBundle(JournalTestUtil.class);
 
-		BundleContext bundleContext = testBundle.getBundleContext();
-
-		Bundle journalServiceBundle = null;
-
-		for (Bundle bundle : bundleContext.getBundles()) {
-			String symbolicName = bundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.journal.service")) {
-				journalServiceBundle = bundle;
-
-				break;
-			}
-		}
-
-		if (journalServiceBundle == null) {
-			throw new ExceptionInInitializerError(
-				"Unable to find com.liferay.journal.service bundle");
-		}
+		Bundle journalServiceBundle = BundleUtil.getBundle(
+			testBundle.getBundleContext(), "com.liferay.journal.service");
 
 		BundleWiring bundleWiring = journalServiceBundle.adapt(
 			BundleWiring.class);

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/web/internal/upgrade/v1_1_0/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/web/internal/upgrade/v1_1_0/test/UpgradePortletPreferencesTest.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -53,7 +54,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 
 import javax.portlet.PortletPreferences;
 
@@ -65,7 +65,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -374,24 +373,8 @@ public class UpgradePortletPreferencesTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			UpgradePortletPreferencesTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Bundle journalContentWebBundle = null;
-
-		for (Bundle curBundle : bundleContext.getBundles()) {
-			if (Objects.equals(
-					curBundle.getSymbolicName(),
-					"com.liferay.journal.content.web")) {
-
-				journalContentWebBundle = curBundle;
-
-				break;
-			}
-		}
-
-		Assert.assertNotNull(
-			"Unable to find journal-content-web bundle",
-			journalContentWebBundle);
+		Bundle journalContentWebBundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.journal.content.web");
 
 		Class<?> clazz = journalContentWebBundle.loadClass(
 			"com.liferay.journal.content.web.internal.upgrade.v1_1_0." +

--- a/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/importer/util/test/KBArticleMarkdownConverterTest.java
+++ b/modules/apps/knowledge-base/knowledge-base-test/src/testIntegration/java/com/liferay/knowledge/base/internal/importer/util/test/KBArticleMarkdownConverterTest.java
@@ -18,6 +18,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -35,7 +36,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 
 /**
@@ -54,17 +54,8 @@ public class KBArticleMarkdownConverterTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			KBArticleMarkdownConverterTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		for (Bundle installedBundle : bundleContext.getBundles()) {
-			String symbolicName = installedBundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.knowledge.base.service")) {
-				bundle = installedBundle;
-
-				break;
-			}
-		}
+		bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.knowledge.base.service");
 
 		Class<?> clazz = bundle.loadClass(
 			"com.liferay.knowledge.base.internal.importer.util." +

--- a/modules/apps/portal-configuration/portal-configuration-extender-test/src/testIntegration/java/com/liferay/portal/configuration/extender/internal/test/ConfiguratorExtenderTest.java
+++ b/modules/apps/portal-configuration/portal-configuration-extender-test/src/testIntegration/java/com/liferay/portal/configuration/extender/internal/test/ConfiguratorExtenderTest.java
@@ -21,6 +21,7 @@ import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -68,21 +69,9 @@ public class ConfiguratorExtenderTest {
 	public void setUp() {
 		Bundle bundle = FrameworkUtil.getBundle(ConfiguratorExtenderTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		String symbolicName = "com.liferay.portal.configuration.extender";
-
-		for (Bundle curBundle : bundleContext.getBundles()) {
-			if (symbolicName.equals(curBundle.getSymbolicName())) {
-				_bundle = curBundle;
-
-				break;
-			}
-		}
-
-		Assert.assertNotNull(
-			"Unable to find bundle with symbolic name: " + symbolicName,
-			_bundle);
+		_bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(),
+			"com.liferay.portal.configuration.extender");
 	}
 
 	@After

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/IndexerRequestBufferTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/IndexerRequestBufferTest.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.module.util.BundleUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.search.test.util.SearchTestRule;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;

--- a/modules/apps/portal/portal-aop-impl/src/main/java/com/liferay/portal/aop/internal/AopServiceRegistrar.java
+++ b/modules/apps/portal/portal-aop-impl/src/main/java/com/liferay/portal/aop/internal/AopServiceRegistrar.java
@@ -19,7 +19,7 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.ProxyUtil;
-import com.liferay.portal.module.util.BundleUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.spring.aop.AopCacheManager;
 import com.liferay.portal.spring.aop.AopInvocationHandler;
 import com.liferay.portal.spring.transaction.TransactionHandler;

--- a/modules/apps/portal/portal-aop-test/src/testIntegration/java/com/liferay/portal/aop/test/AopServiceManagerConcurrencyTest.java
+++ b/modules/apps/portal/portal-aop-test/src/testIntegration/java/com/liferay/portal/aop/test/AopServiceManagerConcurrencyTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.spring.transaction.TransactionAttributeAdapter;
 import com.liferay.portal.spring.transaction.TransactionHandler;
 import com.liferay.portal.spring.transaction.TransactionStatusAdapter;
@@ -74,15 +75,8 @@ public class AopServiceManagerConcurrencyTest {
 		_executorService = Executors.newFixedThreadPool(
 			runtime.availableProcessors());
 
-		for (Bundle currentBundle : _bundleContext.getBundles()) {
-			String symbolicName = currentBundle.getSymbolicName();
-
-			if (symbolicName.equals("com.liferay.portal.aop.impl")) {
-				_aopImplBundle = currentBundle;
-
-				break;
-			}
-		}
+		_aopImplBundle = BundleUtil.getBundle(
+			_bundleContext, "com.liferay.portal.aop.impl");
 
 		Assert.assertNotNull(_aopImplBundle);
 	}

--- a/modules/apps/portal/portal-spring-extender-impl/src/main/java/com/liferay/portal/spring/extender/internal/configuration/PortletConfigurationExtender.java
+++ b/modules/apps/portal/portal-spring-extender-impl/src/main/java/com/liferay/portal/spring/extender/internal/configuration/PortletConfigurationExtender.java
@@ -21,7 +21,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.module.util.BundleUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.util.PropsValues;
 
 import org.osgi.framework.Bundle;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
@@ -29,7 +29,7 @@ import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.version.Version;
-import com.liferay.portal.module.util.BundleUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.upgrade.internal.graph.ReleaseGraphManager;
 import com.liferay.portal.upgrade.internal.registry.UpgradeInfo;
 import com.liferay.portal.upgrade.internal.registry.UpgradeStepRegistratorTracker;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/index/updater/osgi/commands/IndexUpdaterOSGiCommands.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/index/updater/osgi/commands/IndexUpdaterOSGiCommands.java
@@ -16,7 +16,7 @@ package com.liferay.portal.upgrade.internal.index.updater.osgi.commands;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.db.index.IndexUpdaterUtil;
-import com.liferay.portal.module.util.BundleUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 
 import org.apache.felix.service.command.Descriptor;
 

--- a/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/src/testIntegration/java/com/liferay/portal/bundle/blacklist/test/BundleBlacklistTest.java
+++ b/modules/apps/static/portal-bundle-blacklist/portal-bundle-blacklist-test/src/testIntegration/java/com/liferay/portal/bundle/blacklist/test/BundleBlacklistTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.lpkg.deployer.test.util.LPKGTestUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -153,7 +154,7 @@ public class BundleBlacklistTest {
 	@Ignore
 	@Test
 	public void testAddToAndRemoveFromBlacklist() throws Exception {
-		Bundle bundle = _findBundle(_SYMBOLIC_NAME);
+		Bundle bundle = BundleUtil.getBundle(_bundleContext, _SYMBOLIC_NAME);
 
 		Assert.assertEquals(Bundle.ACTIVE, bundle.getState());
 
@@ -181,7 +182,7 @@ public class BundleBlacklistTest {
 
 		_bundleBlacklistManager.removeFromBlacklistAndInstall(_SYMBOLIC_NAME);
 
-		bundle = _findBundle(_SYMBOLIC_NAME);
+		bundle = BundleUtil.getBundle(_bundleContext, _SYMBOLIC_NAME);
 
 		Assert.assertEquals(Bundle.ACTIVE, bundle.getState());
 
@@ -247,13 +248,15 @@ public class BundleBlacklistTest {
 
 		_updateConfiguration(properties);
 
-		warWrapperBundle = _findBundle(warWrapperBundle.getSymbolicName());
+		warWrapperBundle = BundleUtil.getBundle(
+			_bundleContext, warWrapperBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"WAR wrapper bundle not reinstalled", Bundle.ACTIVE,
 			warWrapperBundle.getState());
 
-		warBundle = _findBundle(warBundle.getSymbolicName());
+		warBundle = BundleUtil.getBundle(
+			_bundleContext, warBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"WAR bundle not reinstalled", Bundle.ACTIVE, warBundle.getState());
@@ -272,7 +275,8 @@ public class BundleBlacklistTest {
 
 		_updateConfiguration(properties);
 
-		warBundle = _findBundle(warBundle.getSymbolicName());
+		warBundle = BundleUtil.getBundle(
+			_bundleContext, warBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"WAR bundle not reinstalled", Bundle.ACTIVE, warBundle.getState());
@@ -291,7 +295,8 @@ public class BundleBlacklistTest {
 
 		_updateConfiguration(properties);
 
-		jarBundle = _findBundle(jarBundle.getSymbolicName());
+		jarBundle = BundleUtil.getBundle(
+			_bundleContext, jarBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"JAR bundle not reinstalled", Bundle.ACTIVE, jarBundle.getState());
@@ -321,37 +326,30 @@ public class BundleBlacklistTest {
 
 		_updateConfiguration(properties);
 
-		lpkgBundle = _findBundle(lpkgBundle.getSymbolicName());
+		lpkgBundle = BundleUtil.getBundle(
+			_bundleContext, lpkgBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"LPKG not reinstalled", Bundle.ACTIVE, lpkgBundle.getState());
 
-		jarBundle = _findBundle(jarBundle.getSymbolicName());
+		jarBundle = BundleUtil.getBundle(
+			_bundleContext, jarBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"JAR bundle not reinstalled", Bundle.ACTIVE, jarBundle.getState());
 
-		warWrapperBundle = _findBundle(warWrapperBundle.getSymbolicName());
+		warWrapperBundle = BundleUtil.getBundle(
+			_bundleContext, warWrapperBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"WAR wrapper bundle not reinstalled", Bundle.ACTIVE,
 			warWrapperBundle.getState());
 
-		warBundle = _findBundle(warBundle.getSymbolicName());
+		warBundle = BundleUtil.getBundle(
+			_bundleContext, warBundle.getSymbolicName());
 
 		Assert.assertEquals(
 			"WAR bundle not reinstalled", Bundle.ACTIVE, warBundle.getState());
-	}
-
-	private Bundle _findBundle(String symbolicName) {
-		for (Bundle bundle : _bundleContext.getBundles()) {
-			if (symbolicName.equals(bundle.getSymbolicName())) {
-				return bundle;
-			}
-		}
-
-		throw new IllegalArgumentException(
-			"No bundle installed with symbolic name " + symbolicName);
 	}
 
 	private void _updateConfiguration(Dictionary<String, Object> dictionary)

--- a/modules/apps/static/portal-file-install/portal-file-install-test/src/testIntegration/java/com/liferay/portal/file/install/deploy/test/FileInstallDeployTest.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-test/src/testIntegration/java/com/liferay/portal/file/install/deploy/test/FileInstallDeployTest.java
@@ -19,6 +19,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -222,7 +223,8 @@ public class FileInstallDeployTest {
 
 			installCountDownLatch.await();
 
-			bundle = _getBundle(_TEST_JAR_SYMBOLIC_NAME);
+			bundle = BundleUtil.getBundle(
+				_bundleContext, _TEST_JAR_SYMBOLIC_NAME);
 
 			Assert.assertNotNull(bundle);
 
@@ -316,7 +318,8 @@ public class FileInstallDeployTest {
 
 			installCountDownLatch.await();
 
-			Bundle bundle = _getBundle(_TEST_JAR_SYMBOLIC_NAME);
+			Bundle bundle = BundleUtil.getBundle(
+				_bundleContext, _TEST_JAR_SYMBOLIC_NAME);
 
 			Assert.assertEquals(Bundle.ACTIVE, bundle.getState());
 
@@ -330,7 +333,8 @@ public class FileInstallDeployTest {
 
 			fragmentInstallCountDownLatch.await();
 
-			Bundle fragmentBundle = _getBundle(testFragmentSymbolicName);
+			Bundle fragmentBundle = BundleUtil.getBundle(
+				_bundleContext, testFragmentSymbolicName);
 
 			Assert.assertEquals(Bundle.RESOLVED, fragmentBundle.getState());
 
@@ -418,7 +422,8 @@ public class FileInstallDeployTest {
 
 			installCountDownLatch.await();
 
-			Bundle bundle = _getBundle(_TEST_JAR_SYMBOLIC_NAME);
+			Bundle bundle = BundleUtil.getBundle(
+				_bundleContext, _TEST_JAR_SYMBOLIC_NAME);
 
 			Assert.assertEquals(Bundle.ACTIVE, bundle.getState());
 
@@ -439,8 +444,8 @@ public class FileInstallDeployTest {
 
 			optionalProviderInstallCountDownLatch.await();
 
-			Bundle optionalProviderBundle = _getBundle(
-				testOptionalProviderSymbolicName);
+			Bundle optionalProviderBundle = BundleUtil.getBundle(
+				_bundleContext, testOptionalProviderSymbolicName);
 
 			Assert.assertEquals(
 				Bundle.ACTIVE, optionalProviderBundle.getState());
@@ -469,16 +474,6 @@ public class FileInstallDeployTest {
 
 			_uninstall(testOptionalProviderSymbolicName, optionalProviderPath);
 		}
-	}
-
-	private Bundle _getBundle(String symbolicName) {
-		for (Bundle currentBundle : _bundleContext.getBundles()) {
-			if (Objects.equals(currentBundle.getSymbolicName(), symbolicName)) {
-				return currentBundle;
-			}
-		}
-
-		return null;
 	}
 
 	private void _uninstall(String symbolicName, Path path) throws Exception {

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/persistence/test/LPKGPersistenceStartBundleTest.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/persistence/test/LPKGPersistenceStartBundleTest.java
@@ -15,13 +15,13 @@
 package com.liferay.portal.lpkg.deployer.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.FrameworkUtil;
 
@@ -36,19 +36,8 @@ public class LPKGPersistenceStartBundleTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			LPKGPersistenceStartBundleTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Bundle lpkgPersistenceTestBundle = null;
-
-		for (Bundle testBundle : bundleContext.getBundles()) {
-			String symbolicName = testBundle.getSymbolicName();
-
-			if (symbolicName.equals("lpkg.persistence.test")) {
-				lpkgPersistenceTestBundle = testBundle;
-
-				break;
-			}
-		}
+		Bundle lpkgPersistenceTestBundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "lpkg.persistence.test");
 
 		Assert.assertNotNull(lpkgPersistenceTestBundle);
 

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/persistence/test/LPKGPersistenceStopBundleTest.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/persistence/test/LPKGPersistenceStopBundleTest.java
@@ -15,13 +15,13 @@
 package com.liferay.portal.lpkg.deployer.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.FrameworkUtil;
 
@@ -36,21 +36,8 @@ public class LPKGPersistenceStopBundleTest {
 		Bundle bundle = FrameworkUtil.getBundle(
 			LPKGPersistenceStopBundleTest.class);
 
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Bundle lpkgPersistenceTestBundle = null;
-
-		for (Bundle testBundle : bundleContext.getBundles()) {
-			String symbolicName = testBundle.getSymbolicName();
-
-			if (symbolicName.equals("lpkg.persistence.test")) {
-				lpkgPersistenceTestBundle = testBundle;
-
-				break;
-			}
-		}
-
-		Assert.assertNotNull(lpkgPersistenceTestBundle);
+		Bundle lpkgPersistenceTestBundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "lpkg.persistence.test");
 
 		Assert.assertEquals(
 			Bundle.ACTIVE, lpkgPersistenceTestBundle.getState());

--- a/portal-impl/src/com/liferay/portal/db/index/IndexUpdaterUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/index/IndexUpdaterUtil.java
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.module.util.BundleUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
 
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 94.0.1
+Bundle-Version: 95.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/module/util/BundleUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/module/util/BundleUtil.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portal.module.util;
+package com.liferay.portal.kernel.module.util;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168539

After implementing the test for [LPS-166969](https://issues.liferay.com/browse/LPS-166969) (see https://github.com/liferay-search/liferay-portal/pull/626) I have realized that we are repeating the BundleUtil.getBundle method code everywhere.

In this PR I am replacing all the repeated code with a direct call to BundleUtil.getBundle

I am also moving the existing BundleUtil class from portal-impl to portal-kernel as @tinatian requested here: https://github.com/liferay-core-infra/liferay-portal/pull/2451#issuecomment-1398751798

This BundleUtil is used from both portal-impl classes and OSGI modules code so I think the best option is to move there.
