### PR TITLE
LPS-187534

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -753,7 +753,8 @@ public class DLReferencesExportImportContentProcessor
 
 				boolean relativePortalURL = false;
 
-				if (content.regionMatches(
+				if (((beginPos == 0) && (endPos == content.length())) ||
+					content.regionMatches(
 						true, beginPos - _OFFSET_HREF_ATTRIBUTE, "href=", 0,
 						5) ||
 					content.regionMatches(
@@ -800,9 +801,11 @@ public class DLReferencesExportImportContentProcessor
 							curBeginPos, endPos);
 
 						if (substring.startsWith(hostName) &&
-							(content.regionMatches(
-								true, curBeginPos - _OFFSET_HREF_ATTRIBUTE,
-								"href=", 0, 5) ||
+							(((curBeginPos == 0) &&
+							  (endPos == content.length())) ||
+							 content.regionMatches(
+								 true, curBeginPos - _OFFSET_HREF_ATTRIBUTE,
+								 "href=", 0, 5) ||
 							 content.regionMatches(
 								 true, curBeginPos - _OFFSET_SRC_ATTRIBUTE,
 								 "src=", 0, 4))) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
@@ -485,6 +485,11 @@ public class JournalArticleModelValidator
 			ExportImportContentProcessorRegistryUtil.
 				getExportImportContentProcessor(JournalArticle.class.getName());
 
+		if (smallImage && Validator.isNotNull(smallImageURL)) {
+			exportImportContentProcessor.validateContentReferences(
+				groupId, smallImageURL);
+		}
+
 		exportImportContentProcessor.validateContentReferences(
 			groupId, content);
 	}


### PR DESCRIPTION
- LPS-187534 Validate the smallImageURL in the same way we validate the content
- LPS-187534 If the content variable only contains the URL, it is not necessary to do the content.regionMatches logic
