### PR TITLE
LPD-x Register DSR and CMP site initializer upgrade baselines

### DIFF
--- a/modules/apps/site/site-cmp-site-initializer/build.gradle
+++ b/modules/apps/site/site-cmp-site-initializer/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:site:site-cms-site-initializer-api")
+	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":apps:subscription:subscription-api")
 	compileOnly project(":apps:translation:translation-api")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/upgrade/registry/CMPSiteInitializerUpgradeStepRegistrator.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/upgrade/registry/CMPSiteInitializerUpgradeStepRegistrator.java
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cmp.site.initializer.internal.upgrade.registry;
+
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jorge Díaz
+ */
+@Component(service = UpgradeStepRegistrator.class)
+public class CMPSiteInitializerUpgradeStepRegistrator
+	implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.registerInitialization();
+	}
+
+}

--- a/modules/apps/site/site-dsr-site-initializer/build.gradle
+++ b/modules/apps/site/site-dsr-site-initializer/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:site:site-dsr-site-initializer-api")
+	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":apps:translation:translation-api")
 	compileOnly project(":apps:user:user-taglib")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/site/site-dsr-site-initializer/src/main/java/com/liferay/site/dsr/site/initializer/internal/upgrade/registry/DSRSiteInitializerUpgradeStepRegistrator.java
+++ b/modules/apps/site/site-dsr-site-initializer/src/main/java/com/liferay/site/dsr/site/initializer/internal/upgrade/registry/DSRSiteInitializerUpgradeStepRegistrator.java
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.dsr.site.initializer.internal.upgrade.registry;
+
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jorge Díaz
+ */
+@Component(service = UpgradeStepRegistrator.class)
+public class DSRSiteInitializerUpgradeStepRegistrator
+	implements UpgradeStepRegistrator {
+
+	@Override
+	public void register(Registry registry) {
+		registry.registerInitialization();
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-x

## What Is Being Fixed

The site-dsr-site-initializer and site-cmp-site-initializer modules had no UpgradeStepRegistrator, so the portal upgrade framework never recorded a Release for either. Without a Release baseline, upgrade steps added in future product versions would have no recorded starting schema version to run against.

## How It Is Being Fixed

Add DSRSiteInitializerUpgradeStepRegistrator and CMPSiteInitializerUpgradeStepRegistrator, each of which calls registry.registerInitialization() to seed its module's Release baseline (a no-op 0.0.0 -> 1.0.0 jump on a current portal). Future product versions can then register real upgrade steps from 1.0.0 onward and have them execute correctly. Each module also gains the portal-upgrade-api compileOnly dependency that provides UpgradeStepRegistrator.

## Why Are There No Tests?

These changes add UpgradeStepRegistrators that only call registry.registerInitialization() to register each module's upgrade Release baseline. This is framework wiring with no branching logic to unit-test — the behavior is exercised by the portal upgrade framework itself — and it mirrors the many registerInitialization()-only registrators already in the tree (e.g. AssetDisplayWebUpgradeStepRegistrator), none of which carry unit tests.

## PR Check

**pr-check: PASS** — tested on `0e1ba53eb09ed6b79b1fee81a81473eaae3cf538`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0e1ba53eb09ed6b79b1fee81a81473eaae3cf538"} -->
