### PR TITLE
Test fixes for ci:test:upgrade and ci:test:db-partition

### DIFF
--- a/modules/apps/site/site-dsr-site-initializer/src/main/java/com/liferay/site/dsr/site/initializer/internal/instance/lifecycle/DSRInitialRequestPortalInstanceLifecycleListener.java
+++ b/modules/apps/site/site-dsr-site-initializer/src/main/java/com/liferay/site/dsr/site/initializer/internal/instance/lifecycle/DSRInitialRequestPortalInstanceLifecycleListener.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.site.dsr.site.initializer.internal.constants.DSRConstants;
 import com.liferay.site.dsr.site.initializer.internal.util.SiteInitializerUtil;
 import com.liferay.site.initializer.SiteInitializer;
@@ -46,7 +47,9 @@ public class DSRInitialRequestPortalInstanceLifecycleListener
 
 	@Override
 	protected void doPortalInstanceRegistered(long companyId) throws Exception {
-		if (!LicenseManagerUtil.isAppEnabled(App.DSR)) {
+		if (PropsValues.DATABASE_PARTITION_ENABLED ||
+			!LicenseManagerUtil.isAppEnabled(App.DSR)) {
+
 			return;
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SearchAdministration.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SearchAdministration.macro
@@ -116,9 +116,7 @@ definition {
 
 	@summary = "Default summary"
 	macro startReindex(action = null) {
-		while ((IsElementNotPresent(locator1 = "SearchAdmin#EXECUTE_REINDEX_BUTTON")) && (maxIterations = "50")) {
-			TestUtils.hardRefresh();
-		}
+		TestUtils.hardRefresh();
 
 		Click(
 			key_action = ${action},

--- a/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
@@ -88,7 +88,7 @@ definition {
 
 			var siteNameURL = StringUtil.lowerCase(${siteNameURL});
 
-			Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage");
+			Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage?p_p_id=com_liferay_layout_admin_web_portlet_GroupPagesPortlet");
 		}
 		else if (IsElementNotPresent(locator1 = "ProductMenu#TOGGLE")) {
 			ApplicationsMenu.gotoSite(site = ${site});

--- a/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/Upgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/Upgrade.macro
@@ -13,16 +13,7 @@ definition {
 			specificURL = "http://localhost:8080",
 			userEmailAddress = "test@liferay.com");
 
-		TestUtils.hardRefresh();
-
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "Search");
-
-		Click(
-			key_navItem = "Index Actions",
-			locator1 = "NavBar#NAV_ITEM_LINK");
+		SearchAdministration.openIndexActions();
 
 		SearchAdministration.startReindex(action = "All Search Indexes");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/development/tools/testinginfrastructure/block/macro/TestUtils.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/development/tools/testinginfrastructure/block/macro/TestUtils.macro
@@ -234,20 +234,17 @@ return element.textContent;
 
 	@summary = "Default summary"
 	macro hardRefresh() {
-		var mac = OSDetector.isApple();
+		var cdpParameters = MapUtil.newObjectHashMap();
 
-		if (${mac} == "true") {
-			Type.sendKeys(
-				locator1 = "//body",
-				value1 = "Shift + Command + r");
-		}
-		else {
-			Type.sendKeys(
-				locator1 = "//body",
-				value1 = "Ctrl + Shift + r");
-		}
+		ExecuteCDPCommand(
+			value1 = "Network.enable",
+			value2 = ${cdpParameters});
 
-		WaitForPageLoad();
+		ExecuteCDPCommand(
+			value1 = "Network.clearBrowserCache",
+			value2 = ${cdpParameters});
+
+		Refresh();
 	}
 
 	@summary = "Default summary"


### PR DESCRIPTION
Validation branch cut from `upstream/master`, combining three Poshi test fixes with the DSR product fix they interact with.

| Commit | LPD | Suite | Source |
|---|---|---|---|
| `16825ff` | LPD-98370 | db-partition | brianchandotcom/master |
| `cfa8dbf` | LPD-91510 | upgrade | brianchandotcom/master |
| `315a6d2` | LPD-97433 | upgrade | liferay-database-infra#3813 (open) |
| `57c3a6e` | LPD-97613 | db-partition | liferay-database-infra#3797 (closed) |

LPD-97613 is the root cause behind the db-partition failures, so a green run will not attribute cleanly per-ticket.
